### PR TITLE
Added the ability to add values as environment variables

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -6,6 +6,7 @@
 import logging
 from logging import debug, info, warning, error
 import re
+import os
 import Progress
 from SortedDict import SortedDict
 
@@ -116,6 +117,9 @@ class Config(object):
     def update_option(self, option, value):
         if value is None:
             return
+        #### Handle environment reference
+        if str(value).startswith("$"):
+            return self.update_option(option, os.getenv(str(value)[1:]))
         #### Special treatment of some options
         ## verbosity must be known to "logging" module
         if option == "verbosity":


### PR DESCRIPTION
This is useful when trying to be compatible with an AWS utility which uses environment vavriables. 

Usage example:
[default]
access_key = $AWS_AKI
secret_key = 
acl_public = False
bucket_location = US
