### PR TITLE
Guess MIME types using python-magic

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -34,7 +34,7 @@ try:
         magic_ = magic.Magic(mime=True)
         def mime_magic(file):
             return magic_.from_file(file)
-    except NameError:
+    except AttributeError:
         ## Older python-magic versions
         magic_ = magic.open(magic.MAGIC_MIME)
         magic_.load()


### PR DESCRIPTION
Works with both the low-level magic wrapper available on e.g. Ubuntu in the pyhon-magic package, as well as the newer python-magic package (http://pypi.python.org/pypi/python-magic/).
