### PR TITLE
Fixing KeyError when copying multiple keys (SourceForge bug 3091912)

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 ## Amazon S3 manager
 ## Author: Michal Ludvig <michal@logix.cz>
@@ -509,11 +509,11 @@ def subcmd_cp_mv(args, process_fce, action_str, message):
         for key in remote_list:
             remote_list[key]['dest_name'] = destination_base + key
     else:
-        key = remote_list.keys()[0]
-        if destination_base.endswith("/"):
-            remote_list[key]['dest_name'] = destination_base + key
-        else:
-            remote_list[key]['dest_name'] = destination_base
+        for key in remote_list:
+            if destination_base.endswith("/"):
+                remote_list[key]['dest_name'] = destination_base + key
+            else:
+                remote_list[key]['dest_name'] = destination_base
 
     if cfg.dry_run:
         for key in exclude_list:


### PR DESCRIPTION
When you use 's3cmd cp' to copy multiple keys (without using the recursive flag) you get a Key Error.
s3cmd cp s3://source-bucket/prefix\* s3://target-bucket

Logged here: http://sourceforge.net/tracker/?func=detail&aid=3091912&group_id=178907&atid=887015
and here: https://bugs.launchpad.net/ubuntu/+source/s3cmd/+bug/523586
