### PR TITLE
Follow symlinks, when requested. (Drop recursion detection)

### DIFF
--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -24,18 +24,12 @@ def _fswalk_follow_symlinks(path):
         If a recursive directory link is detected, emit a warning and skip.
         '''
         assert os.path.isdir(path) # only designed for directory argument
-        walkdirs = set([path])
-        targets = set()
+        walkdirs = [path]
         for dirpath, dirnames, filenames in os.walk(path):
                 for dirname in dirnames:
                         current = os.path.join(dirpath, dirname)
-                        target = os.path.realpath(current)
                         if os.path.islink(current):
-                                if target in targets:
-                                        warning("Skipping recursively symlinked directory %s" % dirname)
-                                else:
-                                        walkdirs.add(current)
-                        targets.add(target)
+				walkdirs.append(current)
         for walkdir in walkdirs:
                 for value in os.walk(walkdir):
                         yield value


### PR DESCRIPTION
Recursion detection on symlinks was too restrictive. It would detect the following as recursion:

dir/
    main-1234/
              file1
              file2
    main -> main-1234

This is clearly not a recursion and a common pattern, eg when hosting package repositories.
Python's os.walk also does not do recursion detection. So lets behave like Python stdlib.
