### PR TITLE
Handle empty return bodies when processing S3 errors.

### DIFF
--- a/S3/Exceptions.py
+++ b/S3/Exceptions.py
@@ -44,7 +44,7 @@ class S3Error (S3Exception):
         if response.has_key("headers"):
             for header in response["headers"]:
                 debug("HttpHeader: %s: %s" % (header, response["headers"][header]))
-        if response.has_key("data"):
+        if response.has_key("data") and response["data"]:
             tree = getTreeFromXml(response["data"])
             error_node = tree
             if not error_node.tag == "Error":


### PR DESCRIPTION
Currently error commands that do not return a body cause
s3cmd to output an ugly backtrace. This change checks to
see if the data field of the response is non-empty before
calling `getTreeFromXml` on it. An example of an offending
command is using `s3cmd info` on a nonexistent object.
