### PR TITLE
sync --preserve checks mtime

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -66,7 +66,7 @@ class Config(object):
     enable_multipart = True
     multipart_chunk_size_mb = 15    # MB
     # List of checks to be performed for 'sync'
-    sync_checks = ['size', 'md5']   # 'weak-timestamp'
+    sync_checks = ['size', 'mtime', 'md5']   # 'weak-timestamp'
     # List of compiled REGEXPs
     exclude = []
     include = []

--- a/s3cmd
+++ b/s3cmd
@@ -656,13 +656,6 @@ def cmd_sync_remote2remote(args):
         info(outstr)
 
 def cmd_sync_remote2local(args):
-    def _parse_attrs_header(attrs_header):
-        attrs = {}
-        for attr in attrs_header.split("/"):
-            key, val = attr.split(":")
-            attrs[key] = val
-        return attrs
-
     s3 = S3(Config())
 
     destination_base = args[-1]
@@ -747,7 +740,7 @@ def cmd_sync_remote2local(args):
                 response = s3.object_get(uri, dst_stream, extra_label = seq_label)
                 dst_stream.close()
                 if response['headers'].has_key('x-amz-meta-s3cmd-attrs') and cfg.preserve_attrs:
-                    attrs = _parse_attrs_header(response['headers']['x-amz-meta-s3cmd-attrs'])
+                    attrs = parse_attrs_header(response['headers']['x-amz-meta-s3cmd-attrs'])
                     if attrs.has_key('mode'):
                         os.chmod(dst_file, int(attrs['mode']))
                     if attrs.has_key('mtime') or attrs.has_key('atime'):


### PR DESCRIPTION
This causes an extra HEAD request for each remote file, which greatly
slows down execution, and increases monetary cost $(0.01/10000
requests), but guarantees files whose mtime has changed will get
resync'd.

This is necessary for yum repositories, where repodata/\* files may be
updated but not change size.  It also correctly handles large files
whose md5 values as returned by S3 are incorrect having their content
(and thus mtime) changed, perhaps by RPM signing.
