### PR TITLE
Add support for adding headers in .s3cfg file

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -83,6 +83,7 @@ class Config(object):
     website_index = "index.html"
     website_error = ""
     website_endpoint = "http://%(bucket)s.s3-website-%(location)s.amazonaws.com/"
+    add_headers = ""
 
     ## Creating a singleton
     def __new__(self, configfile = None):
@@ -112,6 +113,12 @@ class Config(object):
         cp = ConfigParser(configfile)
         for option in self.option_list():
             self.update_option(option, cp.get(option))
+
+        if cp.get('add_headers'):
+            for option in cp.get('add_headers').split(","):
+                (key, value) = option.split(':')
+                self.extra_headers[key.replace('_', '-').strip()] = value.strip()
+
         self._parsed_files.append(configfile)
 
     def dump_config(self, stream):


### PR DESCRIPTION
Adding headers with --add-header from the command line is helpful  But, it's sometimes nice to be able to set headers for all files in the .s3cfg. For example, to use AES256 encryption on all files uploaded. There are other places this is useful as well.  It's a simple change that I think adds decent functionality to s3cmd.  Here's how it looks in a config file:

[default]
add_headers = x-amz-server-side-encryption:AES256, x-foo:something
