### PR TITLE
Added swift compatbility support

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -36,6 +36,7 @@ class Config(object):
     acl_public = None
     acl_grants = []
     acl_revokes = []
+    swift_compatible = False
     proxy_host = ""
     proxy_port = 3128
     encrypt = False

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -182,7 +182,10 @@ class S3(object):
         if resource['bucket'] and not check_bucket_name_dns_conformity(resource['bucket']):
             uri = "/%s%s" % (resource['bucket'], resource['uri'])
         else:
-            uri = resource['uri']
+            if self.config.swift_compatible and resource['bucket']:
+                uri = "/%s%s" % (resource['bucket'], resource['uri'])
+            else:
+                uri = resource['uri']
         if self.config.proxy_host != "":
             uri = "http://%s%s" % (self.get_hostname(resource['bucket']), uri)
         debug('format_uri(): ' + uri)


### PR DESCRIPTION
Swift requires the bucket names in all request URIs.

Added swift_compatible = True/False to the config options.
Disabled by default.
