### PR TITLE
Add command line options for AWS access key and secret key

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1481,6 +1481,8 @@ def main():
     optparser.add_option(      "--configure", dest="run_configure", action="store_true", help="Invoke interactive (re)configuration tool. Optionally use as '--configure s3://come-bucket' to test access to a specific bucket instead of attempting to list them all.")
     optparser.add_option("-c", "--config", dest="config", metavar="FILE", help="Config file name. Defaults to %default")
     optparser.add_option(      "--dump-config", dest="dump_config", action="store_true", help="Dump current configuration after parsing config files and command line options and exit.")
+    optparser.add_option(      "--access_key", dest="access_key", help="AWS Access Key")
+    optparser.add_option(      "--secret_key", dest="secret_key", help="AWS Secret Key")
 
     optparser.add_option("-n", "--dry-run", dest="dry_run", action="store_true", help="Only show what should be uploaded or downloaded but don't actually do it. May still perform S3 requests to get bucket listings and other information though (only for file transfer commands)")
 


### PR DESCRIPTION
I'd like to be able to run s3cmd without having to configure the entire application, This pull adds the appropriate options.

Based on this suggestion:
http://sourceforge.net/projects/s3tools/forums/forum/618865/topic/4636398?message=10564589
