### PR TITLE
Added command to set bucket access policy

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -456,6 +456,17 @@ class S3(object):
         response = self.send_request(request, body)
         return response
 
+    def set_policy(self, uri, policy):
+        if uri.has_object():
+            request = self.create_request("OBJECT_PUT", uri = uri, extra = "?policy")
+        else:
+            request = self.create_request("BUCKET_CREATE", bucket = uri.bucket(), extra = "?policy")
+
+        body = str(policy)
+        debug(u"set_policy(%s): policy-json: %s" % (uri, body))
+        response = self.send_request(request, body)
+        return response
+
     def get_accesslog(self, uri):
         request = self.create_request("BUCKET_LIST", bucket = uri.bucket(), extra = "?logging")
         response = self.send_request(request)

--- a/s3cmd
+++ b/s3cmd
@@ -1051,6 +1051,18 @@ def cmd_setacl(args):
         uri = S3Uri(remote_list[key]['object_uri_str'])
         _update_acl(uri, seq_label)
 
+def cmd_setpolicy(args):
+    s3 = S3(cfg)
+    uri = args.pop(0)
+    bucket_uri = S3Uri(uri)
+    if bucket_uri.object():
+        raise ParameterError("Only bucket name is required for [setpolicy] command")
+    policy = args.pop()
+    info("Setting access policy for bucket %s to:\n\n%s" % (bucket_uri.uri(), policy))
+    response = s3.set_policy(bucket_uri, policy)
+    if response['status'] == 204:
+          output(u"%s: Policy updated" % uri)
+
 def cmd_accesslog(args):
     s3 = S3(cfg)
     bucket_uri = S3Uri(args.pop())
@@ -1392,6 +1404,7 @@ def get_commands_list():
     {"cmd":"cp", "label":"Copy object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_cp, "argc":2},
     {"cmd":"mv", "label":"Move object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_mv, "argc":2},
     {"cmd":"setacl", "label":"Modify Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_setacl, "argc":1},
+    {"cmd":"setpolicy", "label":"Set an access policy for a bucket", "param":"s3://BUCKET POLICY_STRING", "func":cmd_setpolicy, "argc":2},
     {"cmd":"accesslog", "label":"Enable/disable bucket access logging", "param":"s3://BUCKET", "func":cmd_accesslog, "argc":1},
     {"cmd":"sign", "label":"Sign arbitrary string using the secret key", "param":"STRING-TO-SIGN", "func":cmd_sign, "argc":1},
     {"cmd":"fixbucket", "label":"Fix invalid file names in a bucket", "param":"s3://BUCKET[/PREFIX]", "func":cmd_fixbucket, "argc":1},


### PR DESCRIPTION
Opening this to get feedback on adding bucket access policy support to s3cmd. Would like to also add delete and list commands, plus some built-in policies (eg. public-read) to make it easier to set them. Thoughts?
