### PR TITLE
Fixed: 's3cmd du' gobbles gigs of RAM on buckets with millions of objects

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -81,8 +81,6 @@ def subcmd_bucket_usage(s3, uri):
 
         # objects in the current scope:
         for obj in response["list"]:
-            if len(response['list']) < 1:
-                break
             bucket_size += int(obj["Size"])
 
         # directories found in current scope:


### PR DESCRIPTION
Re-worked 'du' to traverse the structure and store only the sum at each level, allowing python to free memory at each folder. Went from 4GB consumption (and being killed) on a test bucket with ~50M objects in thousands of directories, to a max of 80M usage.
