### PR TITLE
Raise if read of object bytes returns 0 bytes.

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -826,6 +826,9 @@ class S3(object):
             while (current_position < size_total):
                 this_chunk = size_left > self.config.recv_chunk and self.config.recv_chunk or size_left
                 data = http_response.read(this_chunk)
+                if len(data) == 0: 
+                    raise S3Error("EOF from S3!")
+
                 stream.write(data)
                 if start_position == 0:
                     md5_hash.update(data)


### PR DESCRIPTION
Hello s3cmd maintainers! At wavii we have been seeing s3cmd hang while reading large numbers of medium sized (~4MB) files from S3 within EC2. The symptom is that strace reports an infinite loop of poll, recvfrom. Poll indicates that the socket is closed (POLLHUP) and recvfrom returns 0 each time. The output of netstat indicates that the socket is gone. The S3 class was not respecting a zero byte return from the httplib connection. Without this fix s3cmd hangs once every 2-3 hours under our workload. With the fix it hasn't hanged in over 12 hours. 
- indication of EOF on the socket

PS Thanks for the great tool!
