### PR TITLE
Multipart copy

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -66,7 +66,7 @@ class Config(object):
     enable_multipart = True
     multipart_chunk_size_mb = 15    # MB
     #- minimum size to use multipart remote s3-to-s3 copy with byte range is 5gb
-    multipart_copy_size_gb = 5      # GB
+    #multipart_copy_size = (5 * 1024 * 1024 * 1024) - 1
     multipart_copy_size = 5 * 1024 * 1024 * 1024
     # List of checks to be performed for 'sync'
     sync_checks = ['size', 'md5']   # 'weak-timestamp'

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -65,6 +65,9 @@ class Config(object):
     mime_type = ""
     enable_multipart = True
     multipart_chunk_size_mb = 15    # MB
+    #- minimum size to use multipart remote s3-to-s3 copy with byte range is 5gb
+    multipart_copy_size_gb = 5      # GB
+    multipart_copy_size = 5 * 1024 * 1024 * 1024
     # List of checks to be performed for 'sync'
     sync_checks = ['size', 'md5']   # 'weak-timestamp'
     # List of compiled REGEXPs

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -110,4 +110,104 @@ class MultiPartUpload(object):
         response = self.s3.send_request(request)
         return response
 
+
+class MultiPartCopy(MultiPartUpload):
+
+    # S3 Config or const?
+    MIN_CHUNK_SIZE_MB = 5120    # 5GB
+    MAX_CHUNK_SIZE_MB = 42949672960 # 5TB
+
+    def __init__(self, s3, src_uri, dst_uri, src_size, headers_baseline = {}):
+        self.s3 = s3
+        self.file = self.src_uri = src_uri
+        self.uri  = self.dst_uri = dst_uri
+        # ...
+        self.src_size = src_size
+        self.parts = {}
+        self.headers_baseline = headers_baseline
+        self.upload_id = self.initiate_multipart_copy()
+
+    def initiate_multipart_copy(self):
+        return self.initiate_multipart_upload()
+
+    def copy_all_parts(self):
+        """
+        Execute a full multipart upload copy on a remote file
+        Returns the seq/etag dict
+        """
+        if not self.upload_id:
+            raise RuntimeError("Attempting to use a multipart copy that has not been initiated.")
+
+        size_left = file_size = self.src_size
+        # TODO: only include byte range if remote src file is > 5gb, or get error
+        # > 5368709121  (5 * 1024 * 1024 * 1024)
+        self.chunk_size = self.s3.config.multipart_copy_size
+        nr_parts = file_size / self.chunk_size + (file_size % self.chunk_size and 1)
+        debug("MultiPart: Copying %s in %d parts" % (self.src_uri, nr_parts))
+
+        seq = 1
+        while size_left > 0:
+            offset = self.chunk_size * (seq - 1)
+            current_chunk_size = min(file_size - offset, self.chunk_size)
+            size_left -= current_chunk_size
+            labels = {
+                'source' : unicodise(self.src_uri.uri()),
+                'destination' : unicodise(self.uri.uri()),
+                'extra' : "[part %d of %d, %s]" % (seq, nr_parts, "%d%sB" % formatSize(current_chunk_size, human_readable = True))
+            }
+            try:
+                #self.upload_part(seq, offset, current_chunk_size, labels)
+                self.copy_part(seq, offset, current_chunk_size, labels)
+            except:
+                error(u"Upload copy of '%s' part %d failed. Aborting multipart upload copy." % (self.src_uri, seq))
+                self.abort_copy()
+                raise
+            seq += 1
+
+        debug("MultiPart: Copy finished: %d parts", seq - 1)
+
+    def copy_part(self, seq, offset, chunk_size, labels):
+        """
+        Copy a remote file chunk
+        http://docs.amazonwebservices.com/AmazonS3/latest/API/index.html?mpUploadUploadPart.html
+        http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadUploadPartCopy.html
+        """
+        debug("Copying part %i of %r (%s bytes)" % (seq, self.upload_id, chunk_size))
+
+        # set up headers with copy-params
+        headers = {
+                # TODO: should be /bucket/uri
+                "x-amz-copy-source": "/%s/%s" % (self.src_uri.bucket(), self.src_uri.object())
+        }
+        if chunk_size >= self.s3.config.multipart_copy_size:
+                # TODO: only include byte range if original file is > 5gb?
+                # > 5368709121  (5 * 1024 * 1024 * 1024)
+                headers["x-amz-copy-source-range"] = "bytes=%d-%d" % (offset, offset + chunk_size)
+                
+
+        #    x-amz-copy-source: /source_bucket/sourceObject
+        #    x-amz-copy-source-range:bytes=first-last
+        #    x-amz-copy-source-if-match: etag
+        #    x-amz-copy-source-if-none-match: etag
+        #    x-amz-copy-source-if-unmodified-since: time_stamp
+        #    x-amz-copy-source-if-modified-since: time_stamp
+
+        query_string = "?partNumber=%i&uploadId=%s" % (seq, self.upload_id)
+
+        request = self.s3.create_request("OBJECT_PUT", uri = self.uri, headers = headers, extra = query_string)
+        response = self.s3.send_request(request)
+
+        # etag in xml response
+        #self.parts[seq] = response["headers"]["etag"]
+        self.parts[seq] = getTextFromXml(response["data"], "ETag")
+
+        return response
+
+    def complete_multipart_copy(self):
+        return self.complete_multipart_upload()
+
+    def abort_copy(self):
+        return self.abort_upload()
+
+
 # vim:et:ts=4:sts=4:ai

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -403,8 +403,6 @@ class S3(object):
         response = self.send_request(request)
         return response
 
-# TODO: want to be able to do multi-part copy on remote s3 objects > 5gb
-# instead of Object-PUT  ... multipart upload with header -d
 
     def object_copy(self, src_uri, dst_uri, extra_headers = None):
         if src_uri.type != "s3":
@@ -413,7 +411,7 @@ class S3(object):
             raise ValueError("Expected URI type 's3', got '%s'" % dst_uri.type)
         headers = SortedDict(ignore_case = True)
 
-        # TODO: where do ACL headers go for copy?
+        # TODO: where do ACL headers go for copy?  Should we copy ACL from source?
         if self.config.acl_public:
             headers["x-amz-acl"] = "public-read"
         if self.config.reduced_redundancy:
@@ -421,7 +419,7 @@ class S3(object):
         # if extra_headers:
         #   headers.update(extra_headers)
 
-        ## Multipart decision - can only copy remote s3-to-s3 files over 5gb
+        ## Multipart decision - only do multipart copy for remote s3 files > 5gb
         multipart = False
         # TODO: does it need new config option for: enable_multipart_copy ?
         if self.config.enable_multipart:


### PR DESCRIPTION
I have added support for Multipart Copy (s3 to s3) in porcupie s3cmd/multipart-copy branch. In this way one can remotely copy large files (> 5gb). It reuses the existing MultipartUpload functionality by subclassing and passing byte-ranges of the remote file (copy) instead of actual byte-ranged data from a local file (upload).

It might be useful to others.  I see a few branches out there with more interesting Multipart functionality like threaded uploads and more robust error handling but have not tried to integrate with those features yet.
