### PR TITLE
Take into account additional headers in cp and sync commands.

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -416,10 +416,17 @@ class S3(object):
             headers["x-amz-acl"] = "public-read"
         if self.config.reduced_redundancy:
             headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
-        # if extra_headers:
-        #   headers.update(extra_headers)
+        if extra_headers:
+          headers.update(extra_headers)
         request = self.create_request("OBJECT_PUT", uri = dst_uri, headers = headers)
-        response = self.send_request(request)
+        try:
+            response = self.send_request(request)
+        except Exception, e:
+            if e.status == 412:
+                # PreconditionFailed response - this is ok, just skip
+                return {"status": e.status}
+            else:
+                raise e
         return response
 
     def object_move(self, src_uri, dst_uri, extra_headers = None):

--- a/s3cmd
+++ b/s3cmd
@@ -535,6 +535,9 @@ def subcmd_cp_mv(args, process_fce, action_str, message):
 
         extra_headers = copy(cfg.extra_headers)
         response = process_fce(src_uri, dst_uri, extra_headers)
+        if response['status'] == 412:
+            info(u"Skipping file %s" % src_uri)
+            continue
         output(message % { "src" : src_uri, "dst" : dst_uri })
         if Config().acl_public:
             info(u"Public URL is: %s" % dst_uri.public_url())
@@ -645,6 +648,9 @@ def cmd_sync_remote2remote(args):
         extra_headers = copy(cfg.extra_headers)
         try:
             response = s3.object_copy(src_uri, dst_uri, extra_headers)
+            if response['status'] == 412:
+                output("Skipping file %s" % src_uri)
+                continue
             output("File %(src)s copied to %(dst)s" % { "src" : src_uri, "dst" : dst_uri })
         except S3Error, e:
             error("File %(src)s could not be copied: %(e)s" % { "src" : src_uri, "e" : e })


### PR DESCRIPTION
Support for condition headers.

It is useful for the cp/sync command to support the extra headers, because conditions such as x-amz-copy-source-if-modified-since can be given.
PreconditionFailed errors need to be accounted for in responses, as these are normal when conditions are specified.

Example usage:

`s3cmd cp -r -v --add-header "x-amz-copy-source-if-modified-since:`date -u -d '1 hour ago' | cut -d\ -f 1-4,6`" s3://source-bucket/ s3://dest-bucket/`
