### PR TITLE
--delete-after-fetch option

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -53,6 +53,7 @@ class Config(object):
         #'acl',     # Full ACL (not yet supported)
     ]
     delete_removed = False
+    delete_after_fetch = False
     _doc['delete_removed'] = "[sync] Remove remote S3 objects when local file has been deleted"
     gpg_passphrase = ""
     gpg_command = ""

--- a/s3cmd
+++ b/s3cmd
@@ -448,6 +448,9 @@ def cmd_object_get(args):
             speed_fmt = formatSize(response["speed"], human_readable = True, floating_point = True)
             output(u"File %s saved as '%s' (%d bytes in %0.1f seconds, %0.2f %sB/s)" %
                 (uri, destination, response["size"], response["elapsed"], speed_fmt[0], speed_fmt[1]))
+        if Config().delete_after_fetch:
+            s3.object_delete(uri)
+            output(u"File %s removed after fetch" % (uri))
 
 def cmd_object_del(args):
     for uri_str in args:
@@ -791,6 +794,9 @@ def cmd_sync_remote2local(args):
             output(u"File '%s' stored as '%s' (%d bytes in %0.1f seconds, %0.2f %sB/s) %s" %
                 (uri, unicodise(dst_file), response["size"], response["elapsed"], speed_fmt[0], speed_fmt[1],
                 seq_label))
+        if Config().delete_after_fetch:
+            s3.object_delete(uri)
+            output(u"File '%s' removed after syncing" % (uri))
         total_size += response["size"]
 
     total_elapsed = time.time() - timestamp_start
@@ -1499,6 +1505,7 @@ def main():
 
     optparser.add_option(      "--delete-removed", dest="delete_removed", action="store_true", help="Delete remote objects with no corresponding local file [sync]")
     optparser.add_option(      "--no-delete-removed", dest="delete_removed", action="store_false", help="Don't delete remote objects.")
+    optparser.add_option(      "--delete-after-fetch", dest="delete_after_fetch", action="store_true", help="Delete remote objects after fetching to local file (only for [get] and [sync] commands).")
     optparser.add_option("-p", "--preserve", dest="preserve_attrs", action="store_true", help="Preserve filesystem attributes (mode, ownership, timestamps). Default for [sync] command.")
     optparser.add_option(      "--no-preserve", dest="preserve_attrs", action="store_false", help="Don't store FS attributes")
     optparser.add_option(      "--exclude", dest="exclude", action="append", metavar="GLOB", help="Filenames and paths matching GLOB will be excluded from sync")


### PR DESCRIPTION
Hi,

I've added an option called `--delete-after-fetch`

One of the scenarios I use `s3cmd` for is fetching all of the latest S3/CloudFront logs files that are being put into one of my buckets.

Previously, I was using a combination of `s3cmd sync` then `s3cmd del` to fetch any new log files, the remove them from the bucket.

However, this creates a race condition where if there are any new log files that were uploading after the beginning of the `s3cmd sync`, the `s3cmd del` will remove the new files without my knowledge.

The option `--delete-after-fetch` attempts to solve this, by issuing a S3 delete command only after a successful fetch of a file.  This works for both `s3cmd get` and `s3cmd sync` commands - whenever file is successfully downloaded, it is also removed from the remote S3 bucket.

So instead of `s3cmd sync` followed by a `s3cmd del`, I can now simply do a `s3cmd sync --delete-after-fetch` and know that I won't lose any files.
