### PR TITLE
Trouble with Windows file paths

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -383,7 +383,7 @@ def cmd_object_get(args):
             if destination_base[-1] != os.path.sep:
                 destination_base += os.path.sep
             for key in remote_list:
-                remote_list[key]['local_filename'] = destination_base + key
+                remote_list[key]['local_filename'] = destination_base + key.replace('/', os.path.sep)
         else:
             raise InternalError("WTF? Is it a dir or not? -- %s" % destination_base)
 


### PR DESCRIPTION
I recently had trouble with downloading a WindowsImageBackup file to my Windows Server 2008 machine. After taking it to the debugger I found that python assumed makedirs on line 423 in s3cmd is being passed a valid file path (basename) which is constructed on line 386. The problem is that in windows \ is the path separator (os.path.sep) vs. the / in everything else. I fixed this by using the str.replace("a", "b") function to switch the / with the os.path.sep on line 386 which gets the correct path separator from the OS.
