### PR TITLE
Prevent 's3cmd get' from leaving dangling empty files on failure

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -440,7 +440,14 @@ def cmd_object_get(args):
             except IOError, e:
                 error(u"Skipping %s: %s" % (destination, e.strerror))
                 continue
-        response = s3.object_get(uri, dst_stream, start_position = start_position, extra_label = seq_label)
+        try:
+            response = s3.object_get(uri, dst_stream, start_position = start_position, extra_label = seq_label)
+        except S3Error, e:
+            if not file_exists: # Delete, only if file didn't exist before!
+                debug(u"object_get failed for '%s', deleting..." % (destination,))
+                os.unlink(destination)
+                raise
+
         if response["headers"].has_key("x-amz-meta-s3tools-gpgenc"):
             gpg_decrypt(destination, response["headers"]["x-amz-meta-s3tools-gpgenc"])
             response["size"] = os.stat(destination)[6]


### PR DESCRIPTION
's3cmd get' command opens destination files as 'ab' (append+write) before even trying to download. In effect, if the
file doesn't exist, s3cmd creates it.

This patch resolves an unwanted side-effect empty files being left by s3cmd after an error.
(e.g. file not found, no permission.)

Should only delete files that s3cmd created.

Signed-off-by: Oren Held oren@held.org.il
