### PR TITLE
Fix exception in 'get --continue' if files exist

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -443,6 +443,7 @@ def cmd_object_get(args):
         try:
             response = s3.object_get(uri, dst_stream, start_position = start_position, extra_label = seq_label)
         except S3Error, e:
+            response = {'headers': {}}
             if not file_exists: # Delete, only if file didn't exist before!
                 debug(u"object_get failed for '%s', deleting..." % (destination,))
                 os.unlink(destination)


### PR DESCRIPTION
If I run:

```
s3cmd get s3://mybucket/myfile.mp4
```

Then

```
s3cmd get --continue s3://mybucket/myfile.mp4
```

s3cmd throws an UnboundLocalError. Faking "response" in the catch block fixes this error.

My commit mentions "-r" but it applies with or without recursive downloading.

I'm new to python so alternative ways to fix this are welcome. Thanks.
