### PR TITLE
s3cmd get --continue: fix unwanted silencing of S3Error exception when file exists.

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -446,7 +446,7 @@ def cmd_object_get(args):
             if not file_exists: # Delete, only if file didn't exist before!
                 debug(u"object_get failed for '%s', deleting..." % (destination,))
                 os.unlink(destination)
-                raise
+            raise
 
         if response["headers"].has_key("x-amz-meta-s3tools-gpgenc"):
             gpg_decrypt(destination, response["headers"]["x-amz-meta-s3tools-gpgenc"])


### PR DESCRIPTION
S3Error should always be raised, regardless of the value of file_exists.

Bug reproducible when using get --continue while the target file exists.
The issue was recently introduced by commit 1a051563e.
Thanks @jamiew for noticing the issue.
