### PR TITLE
Fixed a typo in error message

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1741,7 +1741,7 @@ def main():
         sys.exit(1)
 
     if len(args) < commands[command]["argc"]:
-        error(u"Not enough paramters for command '%s'" % command)
+        error(u"Not enough parameters for command '%s'" % command)
         sys.exit(1)
 
     try:


### PR DESCRIPTION
One character change: paramters -> parameters
