### PR TITLE
fix bug in datetime tuple concatenation

### DIFF
--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -173,7 +173,7 @@ def formatDateTime(s3timestamp):
         ## Can't unpack args and follow that with kwargs in python 2.5
         ## So we pass them all as kwargs
         params = zip(('year', 'month', 'day', 'hour', 'minute', 'second', 'tzinfo'),
-                     dateS3toPython(s3timestamp)[0:6] + (tz))
+                     dateS3toPython(s3timestamp)[0:6] + (tz,))
         params = dict(params)
         utc_dt = datetime.datetime(**params)
         dt_object = utc_dt.astimezone(timezone)


### PR DESCRIPTION
On the master version, just doing an s3cmd ls will give this error:

```
Problem: TypeError: can only concatenate tuple (not "UTC") to tuple
S3cmd:   1.5.0-alpha1

Traceback (most recent call last):
  File "/Users/carlo/Projects/datadog/python/bin/s3cmd", line 2037, in <module>
    main()
  File "/Users/carlo/Projects/datadog/python/bin/s3cmd", line 1978, in main
    cmd_func(args)
  File "/Users/carlo/Projects/datadog/python/bin/s3cmd", line 104, in cmd_ls
    subcmd_bucket_list(s3, uri)
  File "/Users/carlo/Projects/datadog/python/bin/s3cmd", line 158, in subcmd_bucket_list
    "timestamp": formatDateTime(object["LastModified"]),
  File "/Users/carlo/Projects/datadog/s3cmd/S3/Utils.py", line 176, in formatDateTime
    dateS3toPython(s3timestamp)[0:6] + (tz))
TypeError: can only concatenate tuple (not "UTC") to tuple
```

It's not doing tuple concatenation because a single element tuple in python is `(elem,)`, not `(elem)`
