### PR TITLE
fix sync --dry-run traceback, bug #124

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1080,7 +1080,7 @@ def cmd_sync_local2remote(args):
             for key in update_list:
                 output(u"upload: %s -> %s" % (update_list[key]['full_name_unicode'], update_list[key]['remote_uri']))
             for (src_obj, dst1, dst2) in copy_pairs:
-                output(u"remote copy: %s -> %s" % (dst1['object_key'], remote_list[dst2]['object_key']))
+                output(u"remote copy: %s -> %s" % (dst1, dst2))
             if cfg.delete_removed:
                 for key in remote_list:
                     output(u"delete: %s" % remote_list[key]['object_uri_str'])


### PR DESCRIPTION
Bug 124: https://github.com/s3tools/s3cmd/issues/124

s3cmd sync --dry-run --recursive BLAH/ s3://blah-blah-blah
would traceback:

File "/usr/local/bin/s3cmd", line 1075, in _child
    output(u"remote copy: %s -> %s" % (dst1['object_key'],
    remote_list[dst2]['object_key']))
TypeError: string indices must be integers

In this case, dst1 and dst2, coming from copy_pairs, are themselves
the strings we want, not a lookup into a list.  So use them directly.
