### PR TITLE
sync remote2remote: set target_uri on updated files too, bug 131

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -656,10 +656,11 @@ def cmd_sync_remote2remote(args):
 
     print(u"Summary: %d source files to copy, %d files at destination to delete" % (src_count, dst_count))
 
-    if src_count > 0:
-        ### Populate 'remote_uri' only if we've got something to sync from src to dst
-        for key in src_list:
-            src_list[key]['target_uri'] = destination_base + key
+    ### Populate 'target_uri' only if we've got something to sync from src to dst
+    for key in src_list:
+        src_list[key]['target_uri'] = destination_base + key
+    for key in update_list:
+        update_list[key]['target_uri'] = destination_base + key
 
     if cfg.dry_run:
         for key in exclude_list:


### PR DESCRIPTION
fixes bug https://github.com/s3tools/s3cmd/issues/131

We were not setting the target_uri field on files that had changed,
only on files that were to be newly uploaded.  This was causing a
traceback when referencing the target_uri field when copying the
changed file.
