### PR TITLE
mktemp permission issue, fix

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -834,7 +834,7 @@ def cmd_sync_remote2local(args):
                 except OSError, e:
                     try: 
                         dst_stream.close() 
-                        os.remove(temp_file)
+                        os.remove(chkptfname)
                     except: pass
                     if e.errno == errno.EEXIST:
                         warning(u"%s exists - not overwriting" % (dst_file))
@@ -849,14 +849,14 @@ def cmd_sync_remote2local(args):
                 except KeyboardInterrupt:
                     try: 
                         dst_stream.close()
-                        os.remove(temp_file)
+                        os.remove(chkptfname)
                     except: pass
                     warning(u"Exiting after keyboard interrupt")
                     return
                 except Exception, e:
                     try: 
                         dst_stream.close()
-                        os.remove(temp_file)
+                        os.remove(chkptfname)
                     except: pass
                     error(u"%s: %s" % (file, e))
                     continue
@@ -865,7 +865,7 @@ def cmd_sync_remote2local(args):
                 # construction :-(
                 try: 
                     dst_stream.close()
-                    os.remove(temp_file)
+                    os.remove(chkptfname)
                 except: pass
             except S3DownloadError, e:
                 error(u"%s: download failed too many times. Skipping that file." % file)


### PR DESCRIPTION
Hello,

We tried out the latest version of s3cmd and encountered an error with respect to file permissions due to the owner-restricted nature of mktemp.  I put together an update which uses os randoms to generate temp file names instead, which allows the permissions on the generated files to reflect the user's umask.  I also added to the existing error handling in order to clean up temp files.

We're looking forward to using s3cmd 1.5 and hope that this permission issue can be resolved either with this patch or with another approach.

Thanks,

Jason
