### PR TITLE
fix sync single remote file to existing local file traceback, bug 88

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -746,6 +746,8 @@ def cmd_sync_remote2local(args):
     info(u"Summary: %d remote files to download, %d local files to delete, %d local files to hardlink" % (remote_count + update_count, local_count, copy_pairs_count))
 
     def _set_local_filename(remote_list, destination_base):
+        if len(remote_list) == 0:
+            return
         if not os.path.isdir(destination_base):
             ## We were either given a file name (existing or not) or want STDOUT
             if len(remote_list) > 1:


### PR DESCRIPTION
fixes https://github.com/s3tools/s3cmd/issues/88

We were getting a traceback:

remote_list[remote_list.keys()[0]]['local_filename'] = deunicodise(destination_base)
IndexError: list index out of range

In this instance, remote_list length is 0 because the file is on the
update_list instead.  We'll get to process that in a bit.  The right
thing to do in _set_local_filename() is to simply return if the list
length is zero - there's nothing for us to do.
