### PR TITLE
Add missing import of errno in S3.py

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -6,6 +6,7 @@
 import sys
 import os, os.path
 import time
+import errno
 import httplib
 import logging
 import mimetypes


### PR DESCRIPTION
The error handling code on line 961 of S3/S3.py uses the `errno` module:

```
if e.errno != errno.ENOENT:
```

However, this module is not imported, leading to a `NameError` when this error case is hit.
