### PR TITLE
fix the public link format for non-DNS-conformant buckets

### DIFF
--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -83,7 +83,7 @@ class S3UriS3(S3Uri):
         if self.is_dns_compatible():
             return "http://%s.%s/%s" % (self._bucket, Config.Config().host_base, self._object)
         else:
-            return "http://%s/%s/%s" % (self._bucket, Config.Config().host_base, self._object)
+            return "http://%s/%s/%s" % (Config.Config().host_base, self._bucket, self._object)
 
     def host_name(self):
         if self.is_dns_compatible():


### PR DESCRIPTION
Noticed the problem while uploading to a bucket with a capital letter in its name. We were getting public links in the wrong form:

http://bucketName/s3.amazonaws.com/filename 

rather than the correct:

http://s3.amazonaws.com/bucketName/filename

The patch fixes it.
