### PR TITLE
Fix crash when cloudfront operations receive 500 errors

### DIFF
--- a/S3/CloudFront.py
+++ b/S3/CloudFront.py
@@ -510,7 +510,7 @@ class CloudFront(object):
                 warning(unicode(e))
                 warning("Waiting %d sec..." % self._fail_wait(retries))
                 time.sleep(self._fail_wait(retries))
-                return self.send_request(op_name, dist_id, body, retries - 1)
+                return self.send_request(op_name, dist_id, body, retries = retries - 1)
             else:
                 raise e
 


### PR DESCRIPTION
When s3cmd encounters a 500 error when talking to the AWS API using cloudfront operations, you can encounter this error:

```
WARNING: Retrying failed request: CreateDist
WARNING: 500 (InternalError):
WARNING: Waiting 3 sec...

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
  Please report the following lines to:
   s3tools-bugs@lists.sourceforge.net
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Problem: TypeError: 'int' object does not support item assignment
S3cmd:   1.0.1

Traceback (most recent call last):
  File "/usr/local/bin/s3cmd", line 2006, in <module>
    main()
  File "/usr/local/bin/s3cmd", line 1950, in main
    cmd_func(args)
  File "/usr/local/Cellar/s3cmd/1.0.1/libexec/S3/CloudFront.py", line 491, in create
    default_root_object = Cmd.options.cf_default_root_object)
  File "/usr/local/Cellar/s3cmd/1.0.1/libexec/S3/CloudFront.py", line 226, in CreateDistribution
    response = self.send_request("CreateDist", body = request_body)
  File "/usr/local/Cellar/s3cmd/1.0.1/libexec/S3/CloudFront.py", line 342, in send_request
    return self.send_request(op_name, dist_id, body, retries - 1)
  File "/usr/local/Cellar/s3cmd/1.0.1/libexec/S3/CloudFront.py", line 320, in send_request
    headers['content-type'] = 'text/plain'
TypeError: 'int' object does not support item assignment
```

The retries parameter was being sent as a positional argument to send_request in the wrong position. I changed it to a keyword argument to fix this issue.
