### PR TITLE
Fix typo/printing error in `report_exception(e)`

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2052,7 +2052,7 @@ def report_exception(e):
 
 """)
         s = ' '.join(sys.argv)
-        sys.stderr.write("""Invoked as: %s""") % s
+        sys.stderr.write("""Invoked as: %s""" % s)
 
         tb = traceback.format_exc(sys.exc_info())
         e_class = str(e.__class__)


### PR DESCRIPTION
Fixes `TypeError: unsupported operand type(s) for %: 'NoneType' and 'str'` arising from using string formatting with the /result/ of sys.stderr.write() instead of the argument to it.
