### PR TITLE
Relax Timeout on IAM Role Request

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -116,7 +116,7 @@ class Config(object):
                 self.role_config()  
 
     def role_config(self):
-        conn = httplib.HTTPConnection(host='169.254.169.254',timeout=0.1)
+        conn = httplib.HTTPConnection(host='169.254.169.254',timeout=2)
         try:
             conn.request('GET', "/latest/meta-data/iam/security-credentials/")
             resp = conn.getresponse()


### PR DESCRIPTION
The current connection timeout for loading IAM role credentials, 0.1 seconds, fails about 5% of the time in the testing we've done.  This patch increases the timeout to 2 seconds and has eliminated the IAM role failures that we were experiencing.  

It may be the case that setting the timeout to a lower value would be adequate, although I'd need to do some testing to confirm.
