### PR TITLE
s3cmd get to stdout: set file_exists to avoid traceback, bug #175

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -446,6 +446,7 @@ def cmd_object_get(args):
         if destination == "-":
             ## stdout
             dst_stream = sys.__stdout__
+            file_exists = True
         else:
             ## File
             try:


### PR DESCRIPTION
Fixes https://github.com/s3tools/s3cmd/issues/175
Reported by Seth Noble.

Set file_exists so we don't try to delete sys.stdout if getting the
file happens to fail.
