### PR TITLE
Allow unicode characters in filenames when using cp

### DIFF
--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -395,7 +395,7 @@ def fetch_remote_list(args, require_attribs = False, recursive = None):
                 remote_list.record_md5(key, objectlist.get_md5(key))
     else:
         for uri in remote_uris:
-            uri_str = str(uri)
+            uri_str = unicode(uri)
             ## Wildcards used in remote URI?
             ## If yes we'll need a bucket listing...
             if uri_str.find('*') > -1 or uri_str.find('?') > -1:


### PR DESCRIPTION
Problem was found when using `s3cmd cp` on a file containing a 'å' character. After this patch the file copied just fine.

This may or may not also fix issue #150. Can not confirm since I have not used the sync command.
