### PR TITLE
Do not retry on I/O errors (IOError exceptions); terminate quietly on EPIPE

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -677,6 +677,8 @@ class S3(object):
         except ParameterError, e:
             raise
         except Exception, e:
+            if isinstance(e, IOError):
+                raise
             if retries:
                 warning("Retrying failed request: %s (%s)" % (resource['uri'], e))
                 warning("Waiting %d sec..." % self._fail_wait(retries))
@@ -728,6 +730,8 @@ class S3(object):
         except Exception, e:
             if self.config.progress_meter:
                 progress.done("failed")
+            if isinstance(e, IOError):
+                raise
             if retries:
                 warning("Retrying failed request: %s (%s)" % (resource['uri'], e))
                 warning("Waiting %d sec..." % self._fail_wait(retries))
@@ -883,6 +887,8 @@ class S3(object):
         except Exception, e:
             if self.config.progress_meter:
                 progress.done("failed")
+            if isinstance(e, IOError):
+                raise
             if retries:
                 warning("Retrying failed request: %s (%s)" % (resource['uri'], e))
                 warning("Waiting %d sec..." % self._fail_wait(retries))
@@ -935,6 +941,8 @@ class S3(object):
         except Exception, e:
             if self.config.progress_meter:
                 progress.done("failed")
+            if isinstance(e, IOError):
+                raise
             if retries:
                 warning("Retrying failed request: %s (%s)" % (resource['uri'], e))
                 warning("Waiting %d sec..." % self._fail_wait(retries))

--- a/s3cmd
+++ b/s3cmd
@@ -2195,6 +2195,11 @@ if __name__ == '__main__':
         sys.stderr.write("See ya!\n")
         sys.exit(1)
 
+    except IOError, e:
+        if e.errno != errno.EPIPE:
+            error(e)
+        sys.exit(1)
+
     except Exception, e:
         report_exception(e)
         sys.exit(1)


### PR DESCRIPTION
I'm often using `s3cmd get $file -` in a shell pipe, e.g., piping results through `head -n2` or the like. Currently this causes s3cmd to retry, which doesn't make sense for most I/O errors including EPIPE. I/O errors should be considered fatal. For EPIPE an error message should not even be printed.
