### PR TITLE
Fix: typo in help message for '--configure'

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1813,7 +1813,7 @@ def main():
     optparser.set_defaults(config = config_file)
     optparser.set_defaults(verbosity = default_verbosity)
 
-    optparser.add_option(      "--configure", dest="run_configure", action="store_true", help="Invoke interactive (re)configuration tool. Optionally use as '--configure s3://come-bucket' to test access to a specific bucket instead of attempting to list them all.")
+    optparser.add_option(      "--configure", dest="run_configure", action="store_true", help="Invoke interactive (re)configuration tool. Optionally use as '--configure s3://some-bucket' to test access to a specific bucket instead of attempting to list them all.")
     optparser.add_option("-c", "--config", dest="config", metavar="FILE", help="Config file name. Defaults to %default")
     optparser.add_option(      "--dump-config", dest="dump_config", action="store_true", help="Dump current configuration after parsing config files and command line options and exit.")
     optparser.add_option(      "--access_key", dest="access_key", help="AWS Access Key")


### PR DESCRIPTION
Minor fix: "come-bucket" --> "some-bucket".
