### PR TITLE
Handle objects on S3 with empty names ('').

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -797,6 +797,7 @@ def cmd_sync_remote2local(args):
 
     info(u"Summary: %d remote files to download, %d local files to delete, %d local files to hardlink" % (remote_count + update_count, local_count, copy_pairs_count))
 
+    empty_fname_re = re.compile(r'\A\s*\Z')
     def _set_local_filename(remote_list, destination_base):
         if len(remote_list) == 0:
             return
@@ -809,7 +810,12 @@ def cmd_sync_remote2local(args):
             if destination_base[-1] != os.path.sep:
                 destination_base += os.path.sep
             for key in remote_list:
-                local_filename = destination_base + key
+                local_basename = key
+                if empty_fname_re.match(key):
+                    # Objects may exist on S3 with empty names (''), which don't map so well to common filesystems.
+                    local_basename = '__AWS-EMPTY-OBJECT-NAME__'
+                    warning(u"Empty object name on S3 found, saving locally as %s" % (local_basename))
+                local_filename = destination_base + local_basename
                 if os.path.sep != "/":
                     local_filename = os.path.sep.join(local_filename.split("/"))
                 remote_list[key]['local_filename'] = deunicodise(local_filename)


### PR DESCRIPTION
Objects may exist on S3 with empty names (''), which don't map so well to common filesystems. This commit handles these empty object names by naming them locally as '**AWS-EMPTY-OBJECT-NAME**'.

Error details:

...
DEBUG: ReceiveFile: Computed MD5 = d41d8cd98f00b204e9800998ecf8427e

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
  Please try reproducing the error using
  the latest s3cmd code from the git master
  branch found at:
    https://github.com/s3tools/s3cmd
  If the error persists, please report the
  following lines (removing any private
  info as necessary) to:
   s3tools-bugs@lists.sourceforge.net
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Invoked as: ./s3cmd -v -d sync s3://bucket/path/ dir/Problem: OSError: [Errno 20] Not a directory
S3cmd:   1.5.0-alpha3

Traceback (most recent call last):
  File "./s3cmd", line 2180, in <module>
    main()
  File "./s3cmd", line 2105, in main
    cmd_func(args)
  File "./s3cmd", line 1259, in cmd_sync
    return cmd_sync_remote2local(args)
  File "./s3cmd", line 946, in cmd_sync_remote2local
    seq, total_size = _download(remote_list, seq, remote_count + update_count, total_size, dir_cache)
  File "./s3cmd", line 905, in _download
    raise e
OSError: [Errno 20] Not a directory

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
  Please try reproducing the error using
  the latest s3cmd code from the git master
  branch found at:
    https://github.com/s3tools/s3cmd
  If the error persists, please report the
  above lines (removing any private
  info as necessary) to:
   s3tools-bugs@lists.sourceforge.net
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
