### PR TITLE
HashCache: catch KeyError in unmark_for_purge(), bug #194

### DIFF
--- a/S3/HashCache.py
+++ b/S3/HashCache.py
@@ -27,7 +27,10 @@ class HashCache(object):
                     self.inodes[d][i][c]['purge'] = True
 
     def unmark_for_purge(self, dev, inode, mtime, size):
-        d = self.inodes[dev][inode][mtime]
+        try:
+            d = self.inodes[dev][inode][mtime]
+        except KeyError:
+            return
         if d['size'] == size and 'purge' in d:
             del self.inodes[dev][inode][mtime]['purge']
 


### PR DESCRIPTION
https://github.com/s3tools/s3cmd/issues/194

If the object isn't in the cache, we can't unmark it - it either never
made it into the cache, or has been deleted (purged) another way.
