### PR TITLE
Latest Greatest Eucalyptus Walrus support!

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -25,6 +25,7 @@ class Config(object):
     access_token = ""
     host_base = "s3.amazonaws.com"
     host_bucket = "%(bucket)s.s3.amazonaws.com"
+    service_path = "" 
     simpledb_host = "sdb.amazonaws.com"
     cloudfront_host = "cloudfront.amazonaws.com"
     verbosity = logging.WARNING

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -132,8 +132,6 @@ class S3Request(object):
         for header in self.headers.keys():
             if header.startswith("x-amz-"):
                 h += header+":"+str(self.headers[header])+"\n"
-        if self.resource['bucket']:
-            h += "/" + self.resource['bucket']
         h += self.resource['uri']
         debug("SignHeaders: " + repr(h))
         signature = sign_string(h)
@@ -633,11 +631,14 @@ class S3(object):
             object = uri.has_object() and uri.object() or None
 
         if bucket:
-            resource['bucket'] = str(bucket)
+            resource['uri'] = "/" + self.urlencode_string(bucket)
             if object:
-                resource['uri'] = "/" + self.urlencode_string(object)
+                 resource['uri'] = resource['uri'] + "/" + self.urlencode_string(object)
         if extra:
             resource['uri'] += extra
+        
+        if self.config.service_path:
+            resource['uri'] = self.config.service_path + resource['uri']
 
         method_string = S3.http_methods.getkey(S3.operations[operation] & S3.http_methods["MASK"])
 

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -57,7 +57,7 @@ def stripNameSpace(xml):
     """
     removeNameSpace(xml) -- remove top-level AWS namespace
     """
-    r = re.compile('^(<?[^>]+?>\s?)(<\w+) xmlns=[\'"](http://[^\'"]+)[\'"](.*)', re.MULTILINE)
+    r = re.compile('^(<?[^>]*>?\s?)(<\w+) xmlns=[\'"](http://[^\'"]+)[\'"](.*)', re.MULTILINE)
     if r.match(xml):
         xmlns = r.match(xml).groups()[2]
         xml = r.sub("\\1\\2\\4", xml)


### PR DESCRIPTION
...loud/tools/patch-s3cmd-0983 patch

That is updated s3cmd based on the old version patch (0.9.8), here it is:
http://www.eucalyptus.com/eucalyptus-cloud/tools/patch-s3cmd-0983

Tested with 3.2.1, 3.2.2

example config:

[default]
access_key = YOUR_ACCESS_KEY
acl_public = False
bucket_location = US
debug_syncmatch = False
default_mime_type = binary/octet-stream
delete_removed = False
dry_run = False
encrypt = False
force = False
gpg_command = None
gpg_decrypt = %(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s
gpg_encrypt = %(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s
gpg_passphrase = 
guess_mime_type = False
host_base = s3.amazonaws.com
host_bucket = %(bucket)s.s3.amazonaws.com
human_readable_sizes = False
preserve_attrs = True
proxy_host = 
proxy_port = 0
recv_chunk = 4096
secret_key = YOUR_SECRET_KEY
send_chunk = 4096
host_base = YOUR_ENDPOINT_IP:8773
host_bucket = YOUR_ENDPOINT_IP:8773
service_path = /services/Walrus
simpledb_host = sdb.amazonaws.com
use_https = False
