### PR TITLE
Fix a logic error in checking for multipart files; prevent HEAD from always being called on every object.

### DIFF
--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -363,7 +363,7 @@ def fetch_remote_list(args, require_attribs = False, recursive = None):
                 'dev' : None,
                 'inode' : None,
             }
-            if rem_list[key]['md5'].find("-"): # always get it for multipart uploads
+            if rem_list[key]['md5'].find("-") != -1: # always get it for multipart uploads
                 _get_remote_attribs(S3Uri(object_uri_str), rem_list[key])
             md5 = rem_list[key]['md5']
             rem_list.record_md5(key, md5)


### PR DESCRIPTION
There was a logic error in checking the MD5 for multipart files; this patch properly checks the output of `find` in order to avoid calling HEAD on every object. Implementing this patch improved `sync` significantly for us, since we normally sync around 2,000 files or more during some of our deployments.
