### PR TITLE
--truncate-response command line option implemented (#209)

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -40,6 +40,7 @@ class Config(object):
     get_continue = False
     skip_existing = False
     recursive = False
+    truncate_response = False
     acl_public = None
     acl_grants = []
     acl_revokes = []

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -225,8 +225,12 @@ class S3(object):
 
     def bucket_list(self, bucket, prefix = None, recursive = None):
         def _list_truncated(data):
-            ## <IsTruncated> can either be "true" or "false" or be missing completely
-            is_truncated = getTextFromXml(data, ".//IsTruncated") or "false"
+            if self.config.truncate_response:
+                # Truncate bucket list response by first 1000 entries
+                is_truncated = "false"
+            else:
+                ## <IsTruncated> can either be "true" or "false" or be missing completely
+                is_truncated = getTextFromXml(data, ".//IsTruncated") or "false"
             return is_truncated.lower() != "false"
 
         def _get_contents(data):

--- a/s3cmd
+++ b/s3cmd
@@ -1827,6 +1827,7 @@ def main():
     optparser.add_option(      "--continue", dest="get_continue", action="store_true", help="Continue getting a partially downloaded file (only for [get] command).")
     optparser.add_option(      "--skip-existing", dest="skip_existing", action="store_true", help="Skip over files that exist at the destination (only for [get] and [sync] commands).")
     optparser.add_option("-r", "--recursive", dest="recursive", action="store_true", help="Recursive upload, download or removal.")
+    optparser.add_option(      "--truncate-response", dest="truncate_response", action="store_true", help="Truncate response of ls command by first 1000 entries.")
     optparser.add_option(      "--check-md5", dest="check_md5", action="store_true", help="Check MD5 sums when comparing files for [sync]. (default)")
     optparser.add_option(      "--no-check-md5", dest="check_md5", action="store_false", help="Do not check MD5 sums when comparing files for [sync]. Only size will be compared. May significantly speed up transfer but may also miss some changed files.")
     optparser.add_option("-P", "--acl-public", dest="acl_public", action="store_true", help="Store objects with ACL allowing read for anyone.")


### PR DESCRIPTION
The problem: ls command with --recursive flag may return billions of entries and it takes minutes for completion or crashes with "Timeout" error (see Issue #209 for more details). 
Resolution: I implemented new command line option --truncate-response that truncates a response of ls command by first 1000 entries. 
