### PR TITLE
Added option --no-mime-magic to prevent mime magic use

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -75,6 +75,7 @@ class Config(object):
     bucket_location = "US"
     default_mime_type = "binary/octet-stream"
     guess_mime_type = True
+    use_mime_magic = True
     mime_type = ""
     enable_multipart = True
     multipart_chunk_size_mb = 15    # MB

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -408,7 +408,7 @@ class S3(object):
         content_type = self.config.mime_type
         content_encoding = None
         if filename != "-" and not content_type and self.config.guess_mime_type:
-            (content_type, content_encoding) = mime_magic(filename)
+            (content_type, content_encoding) = mime_magic(filename) if self.config.use_mime_magic else mimetypes.guess_type(filename)
         if not content_type:
             content_type = self.config.default_mime_type
 

--- a/s3cmd
+++ b/s3cmd
@@ -1863,6 +1863,7 @@ def main():
     optparser.add_option(      "--default-mime-type", dest="default_mime_type", action="store_true", help="Default MIME-type for stored objects. Application default is binary/octet-stream.")
     optparser.add_option("-M", "--guess-mime-type", dest="guess_mime_type", action="store_true", help="Guess MIME-type of files by their extension or mime magic. Fall back to default MIME-Type as specified by --default-mime-type option")
     optparser.add_option(      "--no-guess-mime-type", dest="guess_mime_type", action="store_false", help="Don't guess MIME-type and use the default type instead.")
+    optparser.add_option(      "--no-mime-magic", dest="use_mime_magic", action="store_false", help="Don't use mime magic when guessing MIME-type.")
     optparser.add_option("-m", "--mime-type", dest="mime_type", type="mimetype", metavar="MIME/TYPE", help="Force MIME-type. Override both --default-mime-type and --guess-mime-type.")
 
     optparser.add_option(      "--add-header", dest="add_header", action="append", metavar="NAME:VALUE", help="Add a given HTTP header to the upload request. Can be used multiple times. For instance set 'Expires' or 'Cache-Control' headers (or both) using this options if you like.")

--- a/s3cmd.1
+++ b/s3cmd.1
@@ -253,6 +253,9 @@ Guess MIME-type of files by their extension or mime magic. Fall back to default 
 \fB\-\-no\-guess\-mime\-type\fR
 Don't guess MIME-type and use the default type instead.
 .TP
+\fB\-\-no\-mime\-magic\fR
+Don't use mime magic when guessing MIME-type.
+.TP
 \fB\-m\fR MIME/TYPE, \fB\-\-mime\-type\fR=MIME/TYPE
 Force MIME-type. Override both \fB--default-mime-type\fR and \fB--guess-mime-type\fR.
 .TP


### PR DESCRIPTION
Option --no-mime-magic disables use of mime magic when guessing MIME-type.

This is to address bug #198 that makes s3cmd unusable for web site uploads from Ubuntu.
