### PR TITLE
* S3/Config.py : Get user input aws access key, secret and gpg passphrase out of debug format string.

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -180,7 +180,7 @@ class Config(object):
                     if "key" in data:
                         Config().update_option(data["key"], data["value"])
                         if data["key"] in ("access_key", "secret_key", "gpg_passphrase"):
-                            print_value = (data["value"][:2]+"...%d_chars..."+data["value"][-1:]) % (len(data["value"]) - 3)
+                            print_value = ("%s...%d_chars...%s") % (data["value"][:2], len(data["value"]) - 3, data["value"][-1:])
                         else:
                             print_value = data["value"]
                         debug("env_Config: %s->%s" % (data["key"], print_value))
@@ -274,7 +274,7 @@ class ConfigParser(object):
                     data["value"] = data["value"][1:-1]
                 self.__setitem__(data["key"], data["value"])
                 if data["key"] in ("access_key", "secret_key", "gpg_passphrase"):
-                    print_value = (data["value"][:2]+"...%d_chars..."+data["value"][-1:]) % (len(data["value"]) - 3)
+                    print_value = ("%s...%d_chars...%s") % (data["value"][:2], len(data["value"]) - 3, data["value"][-1:])
                 else:
                     print_value = data["value"]
                 debug("ConfigParser: %s->%s" % (data["key"], print_value))


### PR DESCRIPTION
 If '%' character is included in any of access_key, secret_key or gpg_passphrase, the following error occurs:

```
Invoked as: ./s3cmdProblem: ValueError: unsupported format character 'Y' (0x59) at index 1
S3cmd:   1.5.0-alpha3

Traceback (most recent call last):
  File "./s3cmd", line 2180, in <module>
    main()
  File "./s3cmd", line 1938, in main
    cfg = Config(options.config)
  File "/home/yuryu/s3cmd/S3/Config.py", line 117, in __init__
    self.read_config_file(configfile)
  File "/home/yuryu/s3cmd/S3/Config.py", line 203, in read_config_file
    cp = ConfigParser(configfile)
  File "/home/yuryu/s3cmd/S3/Config.py", line 249, in __init__
    self.parse_file(file, sections)
  File "/home/yuryu/s3cmd/S3/Config.py", line 277, in parse_file
    print_value = (data["value"][:2]+"...%d_chars..."+data["value"][-1:]) % (len(data["value"]) - 3)
ValueError: unsupported format character 'Y' (0x59) at index 1
```

This patch fixes this issue.
