### PR TITLE
HashCache and FileDict: ignore files with device = 0 or inode = 0

### DIFF
--- a/S3/FileDict.py
+++ b/S3/FileDict.py
@@ -36,6 +36,7 @@ class FileDict(SortedDict):
         return md5
 
     def record_hardlink(self, relative_file, dev, inode, md5):
+        if dev == 0 or inode == 0: return # Windows
         if dev not in self.hardlinks:
             self.hardlinks[dev] = dict()
         if inode not in self.hardlinks[dev]:

--- a/S3/HashCache.py
+++ b/S3/HashCache.py
@@ -5,6 +5,7 @@ class HashCache(object):
         self.inodes = dict()
 
     def add(self, dev, inode, mtime, size, md5):
+        if dev == 0 or inode == 0: return # Windows
         if dev not in self.inodes:
             self.inodes[dev] = dict()
         if inode not in self.inodes[dev]:
@@ -27,7 +28,10 @@ class HashCache(object):
                     self.inodes[d][i][c]['purge'] = True
 
     def unmark_for_purge(self, dev, inode, mtime, size):
-        d = self.inodes[dev][inode][mtime]
+        try:
+            d = self.inodes[dev][inode][mtime]
+        except:
+            return
         if d['size'] == size and 'purge' in d:
             del self.inodes[dev][inode][mtime]['purge']
 


### PR DESCRIPTION
Bug #227 affects Windows where these values are zero, leading to sync
believing incorrectly that all local files are the same file.
