### PR TITLE
Fix incorrect content-header assignment and charset bug

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -415,7 +415,7 @@ class S3(object):
             content_charset = self.config.encoding.upper()
 
         ## add charset to content type
-        if self.add_encoding(filename, content_type):
+        if self.add_encoding(filename, content_type) and content_charset is not None:
             content_type = content_type + "; charset=" + content_charset
 
         headers["content-type"] = content_type


### PR DESCRIPTION
```
mime_magic fix for Issue #247:
Originally mime_magic could assign the charset when it assigned
content_encoding. The change in 85bb3ed removed the ability of
mime_magic to set the character set. This reverts that mistake.

Cleanup fix 85bb3ed for bug #153:
The content-encoding header assignment is removed since the
intent was a mistake as described in bug #153.
```
