### PR TITLE
remove python-2.5-ism when guessing mimetype (bug #218)

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -412,7 +412,10 @@ class S3(object):
         content_type = self.config.mime_type
         content_encoding = None
         if filename != "-" and not content_type and self.config.guess_mime_type:
-            (content_type, content_encoding) = mime_magic(filename) if self.config.use_mime_magic else mimetypes.guess_type(filename)
+            if self.config.use_mime_magic:
+                (content_type, content_encoding) = mime_magic(filename)
+            else:
+                (content_type, content_encoding) = mimetypes.guess_type(filename)
         if not content_type:
             content_type = self.config.default_mime_type
 


### PR DESCRIPTION
This syntax doesn't work on python 2.4, which we still support.
