### PR TITLE
fix divide-by-zero when no files were transferred

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -767,6 +767,8 @@ def cmd_sync_remote2remote(args):
     seq = _upload(failed_copy_files, seq, failed_copy_count)
 
     total_elapsed = time.time() - timestamp_start
+    if total_elapsed == 0.0:
+        total_elapsed = 1.0
     outstr = "Done. Copied %d files in %0.1f seconds, %0.2f files/s" % (seq, total_elapsed, seq/total_elapsed)
     if seq > 0:
         output(outstr)


### PR DESCRIPTION
Repored by Jason Woodall to s3tools-bugs 2014-01-06.
