### PR TITLE
--no-check-md5 should disable md5sum calculation, including preserved at...

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2080,10 +2080,14 @@ def main():
     if options.check_md5 == False:
         try:
             cfg.sync_checks.remove("md5")
+            cfg.preserve_attrs_list.remove("md5")
         except Exception:
             pass
-    if options.check_md5 == True and cfg.sync_checks.count("md5") == 0:
-        cfg.sync_checks.append("md5")
+    if options.check_md5 == True:
+        if cfg.sync_checks.count("md5") == 0:
+            cfg.sync_checks.append("md5")
+        if cfg.preserve_attrs_list.count("md5") == 0:
+            cfg.preserve_attrs_list.append("md5")
 
     ## Update Config with other parameters
     for option in cfg.option_list():


### PR DESCRIPTION
...tributes

Fixes https://github.com/s3tools/s3cmd/issues/217

--no-check-md5 removes 'md5' from the cfg.sync_checks list.  It does
not remove it from the cfg.preserve_attrs_list list.  Therefore each
file's md5sum is calculated when generating the preserved attribute
header (which also includes username, groupname, size, obtained from
stat(), ...).  The default for both sync and put is --preserve.

Therefore, to disable md5 generation completely, one needs to also use
--no-preserve.

Another option would be to have --no-check-md5 also remove 'md5' from
cfg.preserve_attrs_list.  I had added 'md5' to the
cfg.preserve_attrs_list list in June 2012 (1.5.0-alpha time period)
when I added hardlink detection, so it's a relatively new change that
is causing md5sums to be calculated by default.  This patch implements
this, --no-check-md5 now removes 'md5' from cfg.preserve_attrs_list.
