### PR TITLE
account for non-ascii filenames

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -905,7 +905,7 @@ def cmd_sync_remote2local(args):
             seq += 1
             item = remote_list[file]
             uri = S3Uri(item['object_uri_str'])
-            dst_file = item['local_filename']
+            dst_file = item['local_filename'].decode('utf-8')
             seq_label = "[%d of %d]" % (seq, total)
             try:
                 dst_dir = os.path.dirname(dst_file)


### PR DESCRIPTION
s3cmd was crasing with the following error message, when trying to sync a file whose filename has accented (non-ascii) characters:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
  Please report the following lines to:
   s3tools-bugs@lists.sourceforge.net
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Problem: UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 123: ordinal not in range(128)
S3cmd:   1.1.0-beta3

Traceback (most recent call last):
  File "/usr/bin/s3cmd", line 1800, in <module>
    main()
  File "/usr/bin/s3cmd", line 1741, in main
    cmd_func(args)
  File "/usr/bin/s3cmd", line 967, in cmd_sync
    return cmd_sync_remote2local(args)
  File "/usr/bin/s3cmd", line 768, in cmd_sync_remote2local
    warning(u"%s is a directory - skipping over" % dst_file)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 123: ordinal not in range(128)

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
    Please report the above lines to:
   s3tools-bugs@lists.sourceforge.net
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

Performing the change suggested in this pull request fixed the problem.
