### PR TITLE
added support for versioned bucket delete

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -135,6 +135,11 @@ class Config(object):
 
             if len(self.access_key)==0:
                 self.role_config()
+            else:
+                if self.access_key[0] == '$':
+                    self.access_key = os.environ.get(self.access_key[1:])
+                if self.secret_key[0] == '$':
+                    self.secret_key = os.environ.get(self.secret_key[1:])
 
     def role_config(self):
         if sys.version_info[0] * 10 + sys.version_info[1] < 26:

--- a/s3cmd
+++ b/s3cmd
@@ -1751,7 +1751,7 @@ def gpg_decrypt(filename, gpgenc_header = "", in_place = True):
 def run_configure(config_file, args):
     cfg = Config()
     options = [
-        ("access_key", "Access Key", "Access key and Secret key are your identifiers for Amazon S3"),
+        ("access_key", "Access Key", "Access key and Secret key are your identifiers for Amazon S3. You can enter $AWS_ACCESS_KEY_ID and $AWS_SECRET_ACCESS_KEY for using the env variables."),
         ("secret_key", "Secret Key"),
         ("gpg_passphrase", "Encryption password", "Encryption password is used to protect your files from reading\nby unauthorized persons while in transfer to S3"),
         ("gpg_command", "Path to GPG program"),


### PR DESCRIPTION
./s3cmd rb -r s3://bucket -now removes the versioned objects as well

Since the bucket-list-versioned request is very similar to bucket-list I took the initiative to create a bucket_list_generic method to avoid duplicated code. The old method is still there and actually sets up the parameters and calls the new one. This affected a few constant strings (e.g response["list"] has now became response["Contents"] in some cases - it follows the names coming from the Amazon API response).

Looking forward for your feedback.

Regards,
Vasi
