### PR TITLE
Missing () while calling lower()

### DIFF
--- a/S3/ACL.py
+++ b/S3/ACL.py
@@ -160,14 +160,14 @@ class ACL(object):
         grantee.permission = permission
 
         if  name.find('@') > -1:
-            grantee.name = grantee.name.lower
+            grantee.name = grantee.name.lower()
             grantee.xsi_type = "AmazonCustomerByEmail"
             grantee.tag = "EmailAddress"
         elif name.find('http://acs.amazonaws.com/groups/') > -1:
             grantee.xsi_type = "Group"
             grantee.tag = "URI"
         else:
-            grantee.name = grantee.name.lower
+            grantee.name = grantee.name.lower()
             grantee.xsi_type = "CanonicalUser"
             grantee.tag = "ID"
 


### PR DESCRIPTION
Fixing bug causing TypeError while setting ACLs
 TypeError: cannot serialize <built-in method lower of str object at 0x2133570> (type builtin_function_or_method)
