### PR TITLE
Bugfix for #303

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -115,18 +115,24 @@ class Config(object):
     expiry_prefix = ""
 
     ## Creating a singleton
-    def __new__(self, configfile = None):
+    def __new__(self, configfile = None, access_key=None, secret_key=None):
         if self._instance is None:
             self._instance = object.__new__(self)
         return self._instance
 
-    def __init__(self, configfile = None):
+    def __init__(self, configfile = None, access_key=None, secret_key=None):
         if configfile:
             try:
                 self.read_config_file(configfile)
             except IOError, e:
                 if 'AWS_CREDENTIAL_FILE' in os.environ:
                     self.env_config()
+
+            # override these if passed on the command-line
+            if access_key and secret_key:
+                self.access_key = access_key
+                self.secret_key = secret_key
+
             if len(self.access_key)==0:
                 self.role_config()
 

--- a/s3cmd
+++ b/s3cmd
@@ -2163,7 +2163,7 @@ def main():
         sys.exit(1)
 
     try:
-        cfg = Config(options.config)
+        cfg = Config(options.config, options.access_key, options.secret_key)
     except IOError, e:
         if options.run_configure:
             cfg = Config()


### PR DESCRIPTION
Allows override of config file or EC2 IAM role credentials with the command-line, fixes the issue where command-line credentials were ignored if role credentials exist.

Fixes #303 - I'm not sure if this is the ideal fix or the preferred way, but it does the job.
