### PR TITLE
Bugfix: don't rely on $HOME to be set

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2020,10 +2020,11 @@ def main():
     config_file = None
     if os.getenv("S3CMD_CONFIG"):
         config_file = os.getenv("S3CMD_CONFIG")
-    elif os.getenv("HOME"):
-        config_file = os.path.join(os.getenv("HOME"), ".s3cfg")
     elif os.name == "nt" and os.getenv("USERPROFILE"):
         config_file = os.path.join(os.getenv("USERPROFILE").decode('mbcs'), "Application Data", "s3cmd.ini")
+    else:
+        from os.path import expanduser
+        config_file = os.path.join(expanduser("~"), ".s3cfg")
 
     preferred_encoding = locale.getpreferredencoding() or "UTF-8"
 


### PR DESCRIPTION
Makes a decent assumption about default platform and pick .s3cfg location using os.path.expanduser, rather than relying on $HOME to be set.  In the case where a config file is not required (such as command-line AWS key arguments or a EC2 instance role), not having $HOME set would erroneously cause an error.
