### PR TITLE
Copy uri_params in bucket_list

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -250,6 +250,7 @@ class S3(object):
         def _get_common_prefixes(data):
             return getListFromXml(data, "CommonPrefixes")
 
+        uri_params = uri_params.copy()
         truncated = True
         list = []
         prefixes = []


### PR DESCRIPTION
When I synced 2 remote buckets with a lot of files, file list of destination bucket was truncated. This is because uri_params dict has key 'marker' from previous call of bucket_list (for source bucket). Copying uri_params solves the issue.
