### PR TITLE
Don't require debug to print message for md5 calculation

### DIFF
--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -162,7 +162,7 @@ def fetch_local_list(args, is_src = False, recursive = None):
 
     def _fetch_local_list_info(loc_list):
         len_loc_list = len(loc_list)
-        info(u"Running stat() and reading/calculating MD5 values on %d files, this may take some time..." % len_loc_list)
+        print (u"Running stat() and reading/calculating MD5 values on %d files, this may take some time..." % len_loc_list)
         counter = 0
         for relative_file in loc_list:
             counter += 1


### PR DESCRIPTION
It would be nice to change the log level when the md5 calculation is starting, so you don't have to be in debug mode to see this message. The way it existed before, it will start it silently and the user has no idea what it is doing. I originally pointed a 100gb file at s3cmd and left it running for a very long time and I eventually thought that s3cmd had hung, when it turns out it was just performing a very long md5 calculation (and operating as normal) before eventually letting the user know it is splitting up the files and starting to upload them. 

This change will make the line "Running stat() and reading/calculating MD5 values on 1 files, this may take some time..." appear to users outside of debug mode. 
