### PR TITLE
Raise Parameter Error if both encryption and stdin upload are specified

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -371,6 +371,8 @@ def cmd_object_put(args):
         full_name = full_name_orig
         seq_label = "[%d of %d]" % (seq, local_count)
         if Config().encrypt:
+	    if key == "-" :
+		 raise ParameterError("Cannot encrypt before uploading from stdin")
             gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
         if cfg.preserve_attrs or local_list[key]['size'] > (cfg.multipart_chunk_size_mb * 1024 * 1024):
             attr_header = _build_attr_header(local_list, key)


### PR DESCRIPTION
Small (and hopefully temporary until functionality can be implemented) change to notify user when they try to use "-" to upload from stdin and -e to encrypt before uploading that this will fail.  Otherwise, it appears to work but uploads an encrypted file with no contents and reports success. 

Fixes #351

Old output:

```
cat mytest | s3cmd put -e - s3://dump/test/mytest
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
/tmp/tmpfile-NuTqRH8ZZd91i42z5GXE -> s3://dump/test/mytest  [1 of 1]
 40 of 40   100% in    0s    87.15 B/s  done
```

New output

```
cat mytest | s3cmd put -e - s3://dump/test/mytest
ERROR: Parameter problem: Cannot encrypt before uploading from stdin
```
