### PR TITLE
Bugfix import error

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2528,7 +2528,7 @@ if __name__ == '__main__':
 
     except ImportError, e:
         report_exception(e)
-        sys.exit(EX_GENERAL)
+        sys.exit(1)
 
     except (ParameterError, InvalidFileError), e:
         error(u"Parameter problem: %s" % e)


### PR DESCRIPTION
Remove unicodise and EX_GENERAL references in the code to catch and report import errors, as they will not be defined if all the imports fail. It prevents the user from receiving accurate debug info, and causes the program to crash. 
