### PR TITLE
Ftx stdin encrypt

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -73,7 +73,8 @@ class Config(object):
     _doc['delete_removed'] = "[sync] Remove remote S3 objects when local file has been deleted"
     delay_updates = False
     gpg_passphrase = ""
-    gpg_command = ""
+    gpg_command = "/usr/bin/gpg"
+    gpg_stream  = "%(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase %(passphrase)s"    
     gpg_encrypt = "%(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s"
     gpg_decrypt = "%(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s"
     use_https = False

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -74,7 +74,7 @@ class Config(object):
     delay_updates = False
     gpg_passphrase = ""
     gpg_command = "/usr/bin/gpg"
-    gpg_stream  = "%(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase %(passphrase)s"    
+    gpg_stream  = "%(gpg_command)s -c -a --verbose --no-use-agent --batch --yes --passphrase %(passphrase)s"
     gpg_encrypt = "%(gpg_command)s -c --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s"
     gpg_decrypt = "%(gpg_command)s -d --verbose --no-use-agent --batch --yes --passphrase-fd %(passphrase_fd)s -o %(output_file)s %(input_file)s"
     use_https = False

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -118,7 +118,6 @@ class MultiPartUpload(object):
                 seq += 1
         else:
             if self.s3.config.encrypt == True:
-                self.headers_baseline['x-amz-meta-s3tools-gpgenc']='gpg'
                 args = {
                     "gpg_command" : self.s3.config.gpg_command,
                     "passphrase" : self.s3.config.gpg_passphrase,

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -125,49 +125,37 @@ class MultiPartUpload(object):
                 }
                 info(u"Encrypting stdin...")
                 command = resolve_list(self.s3.config.gpg_stream.split(" "), args)
-
                 debug("GPG command: " + " ".join(command))
-                p = subprocess.Popen(command, stdin = subprocess.PIPE, stdout = subprocess.PIPE, stderr = subprocess.STDOUT, bufsize=self.chunk_size)
-                
-                while True:
-                    #print self.file
-                    buffer = self.file.read(self.chunk_size)
-                    offset = self.chunk_size * (seq - 1)
-                    current_chunk_size = len(buffer)
-                    labels = {
-                        'source' : unicodise(self.file.name),
-                        'destination' : unicodise(self.uri.uri()),
-                        'extra' : "[part %d, %s]" % (seq, "%d%sB" % formatSize(current_chunk_size, human_readable = True))
-                    }
-                    if len(buffer) == 0: # EOF
-                        break
-                    try:
-                        self.upload_part(seq, offset, current_chunk_size, labels, buffer, remote_status = remote_statuses.get(seq))
-                    except:
-                        error(u"\nUpload of '%s' part %d failed. Use\n  %s abortmp %s %s\nto abort, or\n  %s --upload-id %s put ...\nto continue the upload."
-                              % (self.file.name, seq, self.uri, sys.argv[0], self.upload_id, sys.argv[0], self.upload_id))
-                        raise
-                    seq += 1
-                
+                p = subprocess.Popen(command, stdin = sys.stdin, stdout = subprocess.PIPE)
+                stream=p.stdout
             else:
-                while True:
-                    buffer = self.file.read(self.chunk_size)
-                    offset = self.chunk_size * (seq - 1)
-                    current_chunk_size = len(buffer)
-                    labels = {
-                        'source' : unicodise(self.file.name),
-                        'destination' : unicodise(self.uri.uri()),
-                        'extra' : "[part %d, %s]" % (seq, "%d%sB" % formatSize(current_chunk_size, human_readable = True))
-                    }
-                    if len(buffer) == 0: # EOF
+                stream=self.file
+            cont = True
+            while cont:
+                buffer = stream.read(self.chunk_size)
+                offset = self.chunk_size * (seq - 1)
+                current_chunk_size = len(buffer)
+                labels = {
+                    'source' : unicodise(self.file.name),
+                    'destination' : unicodise(self.uri.uri()),
+                    'extra' : "[part %d, %s]" % (seq, "%d%sB" % formatSize(current_chunk_size, human_readable = True))
+                }
+                if len(buffer) == 0: # EOF
+                    if self.s3.config.encrypt == True:
+                        p.wait()
+                        buffer=stream.read()
+                        cont=False
+                        if len(buffer) ==0:
+                            break;
+                    else:
                         break
-                    try:
-                        self.upload_part(seq, offset, current_chunk_size, labels, buffer, remote_status = remote_statuses.get(seq))
-                    except:
-                        error(u"\nUpload of '%s' part %d failed. Use\n  %s abortmp %s %s\nto abort, or\n  %s --upload-id %s put ...\nto continue the upload."
-                              % (self.file.name, seq, self.uri, sys.argv[0], self.upload_id, sys.argv[0], self.upload_id))
-                        raise
-                    seq += 1
+                try:
+                    self.upload_part(seq, offset, current_chunk_size, labels, buffer, remote_status = remote_statuses.get(seq))
+                except:
+                    error(u"\nUpload of '%s' part %d failed. Use\n  %s abortmp %s %s\nto abort, or\n  %s --upload-id %s put ...\nto continue the upload."
+                          % (self.file.name, seq, self.uri, sys.argv[0], self.upload_id, sys.argv[0], self.upload_id))
+                    raise
+                seq += 1
 
         debug("MultiPart: Upload finished: %d parts", seq - 1)
 

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -511,7 +511,11 @@ except ImportError:
 
 __all__.append("getgrgid_grpname")
 
-
+def resolve_list(lst, args):
+    retval = []
+    for item in lst:
+        retval.append(item % args)
+    return retval
 
 # vim:et:ts=4:sts=4:ai
 

--- a/s3cmd
+++ b/s3cmd
@@ -373,7 +373,7 @@ def cmd_object_put(args):
         if Config().encrypt:
             if key == "-" : #deal with encrypting stdin in multipart upload
                 extra_headers["x-amz-meta-s3tools-gpgenc"]="gpg"
-            else
+            else:
                 gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
         if cfg.preserve_attrs or local_list[key]['size'] > (cfg.multipart_chunk_size_mb * 1024 * 1024):
             attr_header = _build_attr_header(local_list, key)

--- a/s3cmd
+++ b/s3cmd
@@ -371,7 +371,9 @@ def cmd_object_put(args):
         full_name = full_name_orig
         seq_label = "[%d of %d]" % (seq, local_count)
         if Config().encrypt:
-            if not key == "-" : #deal with encrypting stdin in multipart upload
+            if key == "-" : #deal with encrypting stdin in multipart upload
+                extra_headers["x-amz-meta-s3tools-gpgenc"]="gpg"
+            else
                 gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
         if cfg.preserve_attrs or local_list[key]['size'] > (cfg.multipart_chunk_size_mb * 1024 * 1024):
             attr_header = _build_attr_header(local_list, key)

--- a/s3cmd
+++ b/s3cmd
@@ -371,7 +371,16 @@ def cmd_object_put(args):
         full_name = full_name_orig
         seq_label = "[%d of %d]" % (seq, local_count)
         if Config().encrypt:
+<<<<<<< HEAD
             gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
+=======
+            if key == "-" :
+                extra_headers["x-amz-meta-s3tools-gpgenc"]="gpg"
+                #raise ParameterError("Cannot encrypt before uploading from stdin")
+                #deal with it later
+            else:
+                gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
+>>>>>>> e650499... Started adding gpg streaming encryption
         if cfg.preserve_attrs or local_list[key]['size'] > (cfg.multipart_chunk_size_mb * 1024 * 1024):
             attr_header = _build_attr_header(local_list, key)
             debug(u"attr_header: %s" % attr_header)
@@ -1727,11 +1736,6 @@ def cmd_fixbucket(args):
         warning("them publicly readable if required.")
     return EX_OK
 
-def resolve_list(lst, args):
-    retval = []
-    for item in lst:
-        retval.append(item % args)
-    return retval
 
 def gpg_command(command, passphrase = ""):
     debug("GPG command: " + " ".join(command))

--- a/s3cmd
+++ b/s3cmd
@@ -371,16 +371,9 @@ def cmd_object_put(args):
         full_name = full_name_orig
         seq_label = "[%d of %d]" % (seq, local_count)
         if Config().encrypt:
-<<<<<<< HEAD
             gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
-=======
-            if key == "-" :
-                extra_headers["x-amz-meta-s3tools-gpgenc"]="gpg"
-                #raise ParameterError("Cannot encrypt before uploading from stdin")
-                #deal with it later
-            else:
+            if not key == "-" : #deal with encrypting stdin in multipart upload
                 gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
->>>>>>> e650499... Started adding gpg streaming encryption
         if cfg.preserve_attrs or local_list[key]['size'] > (cfg.multipart_chunk_size_mb * 1024 * 1024):
             attr_header = _build_attr_header(local_list, key)
             debug(u"attr_header: %s" % attr_header)
@@ -2523,6 +2516,7 @@ if __name__ == '__main__':
         from S3.CloudFront import CloudFront
         from S3.FileLists import *
         from S3.MultiPart import MultiPartUpload
+        from S3.Utils import resolve_list
 
         rc = main()
         sys.exit(rc)

--- a/s3cmd
+++ b/s3cmd
@@ -371,7 +371,6 @@ def cmd_object_put(args):
         full_name = full_name_orig
         seq_label = "[%d of %d]" % (seq, local_count)
         if Config().encrypt:
-            gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
             if not key == "-" : #deal with encrypting stdin in multipart upload
                 gpg_exitcode, full_name, extra_headers["x-amz-meta-s3tools-gpgenc"] = gpg_encrypt(full_name_orig)
         if cfg.preserve_attrs or local_list[key]['size'] > (cfg.multipart_chunk_size_mb * 1024 * 1024):


### PR DESCRIPTION
Enable encryption when uploading from stdin using the -e encryption flag.

Uses a new config parameter gpg_stream with the added argument of -a (armor) to specify the command to use.  Armor is necessary to allow the subprocess to work correctly and write an eof that gpg can understand

A subprocess is added before the multipart upload to pipe stdin into and out of gpg.

Additionally, resolve_list was moved to utils to allow its access in multipart uploads

Fixes #351
Replaces #354
