### PR TITLE
fix issue with error display after config modify

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -223,7 +223,7 @@ class Config(object):
     def read_config_file(self, configfile):
         cp = ConfigParser(configfile)
         for option in self.option_list():
-            self.update_option(option, cp.get(option))
+            self.update_option(option, cp.get(option).strip())
 
         if cp.get('add_headers'):
             for option in cp.get('add_headers').split(","):


### PR DESCRIPTION
I was running into an problem with errors displaying after modifying config file values. ex:

```
ERROR: Config: value of option 'use_https' must be Yes or No, not 'False '
```

This fix removes whitespace from those config values to resolve the issue.
