### PR TITLE
Support for SSE-C

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -38,6 +38,7 @@ class Config(object):
     extra_headers = SortedDict(ignore_case = True)
     force = False
     server_side_encryption = False
+    sse_customer_key = None
     enable = None
     get_continue = False
     put_continue = False

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -38,7 +38,7 @@ class Config(object):
     extra_headers = SortedDict(ignore_case = True)
     force = False
     server_side_encryption = False
-    sse_customer_key = None
+    sse_customer_key = ""
     enable = None
     get_continue = False
     put_continue = False

--- a/S3/FileDict.py
+++ b/S3/FileDict.py
@@ -38,7 +38,7 @@ class FileDict(SortedDict):
         if 'md5' in self[relative_file]:
             return self[relative_file]['md5']
         md5 = self.get_hardlink_md5(relative_file)
-        if md5 is None and 'md5' in cfg.sync_checks:
+        if md5 is None and 'md5' in cfg.preserve_attrs_list:
             logging.debug(u"doing file I/O to read md5 of %s" % relative_file)
             md5 = Utils.hash_file_md5(self[relative_file]['full_name'])
         self.record_md5(relative_file, md5)

--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -494,6 +494,23 @@ def compare_filelists(src_list, dst_list, src_remote, dst_remote, delay_updates 
                 attribs_match = False
                 debug(u"XFER: %s (md5 mismatch: src=%s dst=%s)" % (file, src_md5, dst_md5))
 
+        # Check mtime. This compares local mtime to the upload time of remote file
+        compare_mtime = 'mtime' in cfg.sync_checks
+        if attribs_match and compare_mtime:
+            try:
+                src_mtime = src_list[file]['mtime']
+                dst_mtime = dst_list[file]['timestamp']
+            except (IOError,OSError), e:
+                # mtime sum verification failed - ignore that file altogether
+                debug(u"IGNR: %s (disappeared)" % (file))
+                warning(u"%s: file disappeared, ignoring." % (file))
+                raise
+
+            if src_mtime > dst_mtime:
+                ## checksums are different.
+                attribs_match = False
+                debug(u"XFER: %s (mtime newer than last upload: src=%s dst=%s)" % (file, UnixtoDate(src_mtime), UnixtoDate(dst_mtime)))
+
         return attribs_match
 
     # we don't support local->local sync, use 'rsync' or something like that instead ;-)

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1019,7 +1019,7 @@ class S3(object):
             raise S3Error(response)
 
         debug("MD5 sums: computed=%s, received=%s" % (md5_computed, response["headers"]["etag"]))
-        if response["headers"]["etag"].strip('"\'') != md5_hash.hexdigest():
+        if self.config.sse_customer_key is None and response["headers"]["etag"].strip('"\'') != md5_hash.hexdigest():
             warning("MD5 Sums don't match!")
             if retries:
                 warning("Retrying upload of %s" % (file.name))

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -165,6 +165,10 @@ def dateS3toUnix(date):
     return timegm(dateS3toPython(date).utctimetuple())
 __all__.append("dateS3toUnix")
 
+def UnixtoDate(epoch):
+    return time.ctime(epoch)
+__all__.append("UnixtoDate")
+
 def dateRFC822toPython(date):
     return dateutil.parser.parse(date, fuzzy=True)
 __all__.append("dateRFC822toPython")

--- a/s3cmd
+++ b/s3cmd
@@ -2294,16 +2294,28 @@ def main():
             cfg.progress_meter = False
 
     if options.sse_customer_key is not None:
-        cfg.sse_customer_key = options.sse_customer_key
+        if len(options.sse_customer_key) ==32:
+            cfg.sse_customer_key = options.sse_customer_key
+        else:
+            error(u"sse-customer-key must be 32 characters")
+            sys.exit(EX_CONFIG)
 
-    if cfg.sse_customer_key is not None:
+    if cfg.sse_customer_key:
         md5 = hashlib.md5()
-        md5.update(options.sse_customer_key)
+        md5.update(cfg.sse_customer_key)
         md5_encoded = base64.b64encode(md5.digest())
-        encoded = base64.b64encode(options.sse_customer_key)
+        encoded = base64.b64encode(cfg.sse_customer_key)
         cfg.extra_headers["x-amz-server-side-encryption-customer-algorithm"] = "AES256"
         cfg.extra_headers["x-amz-server-side-encryption-customer-key"] = encoded
         cfg.extra_headers["x-amz-server-side-encryption-customer-key-md5"] = md5_encoded
+        
+        debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-server-side-encryption-customer-algorithm", "AES256"))
+        debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-server-side-encryption-customer-key", encoded))
+        debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-server-side-encryption-customer-key-md5", md5_encoded))
+
+        # Force check-md5 option to off because the returned checksums will not match
+        options.check_md5 = False
+        debug(u"Forcing check_md5 to False")
 
     if options.sse_copy_source_customer_key is not None:
         md5 = hashlib.md5()
@@ -2313,6 +2325,10 @@ def main():
         cfg.extra_headers["x-amz-copy-source-server-side-encryption-customer-algorithm"] = "AES256"
         cfg.extra_headers["x-amz-copy-source-server-side-encryption-customer-key"] = encoded
         cfg.extra_headers["x-amz-copy-source-server-side-encryption-customer-key-md5"] = md5_encoded
+        
+        debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-copy-source-server-side-encryption-customer-algorithm", "AES256"))
+        debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-copy-source-server-side-encryption-customer-key", encoded))
+        debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-copy-source-server-side-encryption-customer-key-md5", md5_encoded))
 
     ## Pre-process --add-header's and put them to Config.extra_headers SortedDict()
     if options.add_header:

--- a/s3cmd
+++ b/s3cmd
@@ -1445,7 +1445,6 @@ def cmd_sync_local2remote(args):
     if cfg.sse_customer_key:
         try:
             cfg.sync_checks.remove("md5")
-            cfg.preserve_attrs_list.remove("md5")
         except Exception:
             pass
         if cfg.sync_checks.count("mtime") == 0:

--- a/s3cmd
+++ b/s3cmd
@@ -2200,8 +2200,8 @@ def main():
     optparser.add_option(      "--add-header", dest="add_header", action="append", metavar="NAME:VALUE", help="Add a given HTTP header to the upload request. Can be used multiple times. For instance set 'Expires' or 'Cache-Control' headers (or both) using this option.")
 
     optparser.add_option(      "--server-side-encryption", dest="server_side_encryption", action="store_true", help="Specifies that server-side encryption will be used when putting objects.")
-    optparser.add_option(      "--sse-customer-key", dest="sse_customer_key", action="store", help="Specifies a customer provided key for server-side encryption. Must be 32 characters for AES256.")
-    optparser.add_option(      "--sse-copy-source-customer-key", dest="sse_copy_source_customer_key", action="store", help="Specifies the encryption key for copying or moving objects with a customer provided key for server-side encryption.")
+    optparser.add_option(      "--sse-customer-key", dest="sse_customer_key", action="store", metavar="12345678901234567890123456789012", help="Specifies a customer provided key for server-side encryption. Must be 32 character string.")
+    optparser.add_option(      "--sse-copy-source-customer-key", dest="sse_copy_source_customer_key", action="store", metavar="12345678901234567890123456789012", help="Specifies the encryption key for copying or moving objects with a customer provided key for server-side encryption.")
 
     optparser.add_option(      "--encoding", dest="encoding", metavar="ENCODING", help="Override autodetected terminal and filesystem encoding (character set). Autodetected: %s" % preferred_encoding)
     optparser.add_option(      "--add-encoding-exts", dest="add_encoding_exts", metavar="EXTENSIONs", help="Add encoding to these comma delimited extensions i.e. (css,js,html) when uploading to S3 )")

--- a/s3cmd
+++ b/s3cmd
@@ -1441,6 +1441,16 @@ def cmd_sync_local2remote(args):
         error(u"or disable encryption with --no-encrypt parameter.")
         sys.exit(EX_USAGE)
 
+    # Disable md5 checks if using SSE-C. Add mtime check
+    if cfg.sse_customer_key:
+        try:
+            cfg.sync_checks.remove("md5")
+            cfg.preserve_attrs_list.remove("md5")
+        except Exception:
+            pass
+        if cfg.sync_checks.count("mtime") == 0:
+            cfg.sync_checks.append("mtime")
+        
     local_list, single_file_local, src_exclude_list = fetch_local_list(args[:-1], is_src = True, recursive = True)
 
     destinations = [args[-1]]
@@ -2312,10 +2322,6 @@ def main():
         debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-server-side-encryption-customer-algorithm", "AES256"))
         debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-server-side-encryption-customer-key", encoded))
         debug(u"Updating Config.Config extra_headers[%s] -> %s" % ("x-amz-server-side-encryption-customer-key-md5", md5_encoded))
-
-        # Force check-md5 option to off because the returned checksums will not match
-        options.check_md5 = False
-        debug(u"Forcing check_md5 to False")
 
     if options.sse_copy_source_customer_key is not None:
         md5 = hashlib.md5()

--- a/s3cmd
+++ b/s3cmd
@@ -38,6 +38,8 @@ import htmlentitydefs
 import socket
 import shutil
 import tempfile
+import base64
+import hashlib
 
 from copy import copy
 from optparse import OptionParser, Option, OptionValueError, IndentedHelpFormatter
@@ -1781,6 +1783,7 @@ def run_configure(config_file, args):
         ("secret_key", "Secret Key"),
         ("gpg_passphrase", "Encryption password", "Encryption password is used to protect your files from reading\nby unauthorized persons while in transfer to S3"),
         ("gpg_command", "Path to GPG program"),
+        ("sse_customer_key", "Encryption key for server-side-encryption with customer key.\nMust be 32 characters"),
         ("use_https", "Use HTTPS protocol", "When using secure HTTPS protocol all communication with Amazon S3\nservers is protected from 3rd party eavesdropping. This method is\nslower than plain HTTP and can't be used if you're behind a proxy"),
         ("proxy_host", "HTTP Proxy server name", "On some networks all internet access must go through a HTTP proxy.\nTry setting it here if you can't connect to S3 directly"),
         ("proxy_port", "HTTP Proxy server port"),
@@ -2187,6 +2190,8 @@ def main():
     optparser.add_option(      "--add-header", dest="add_header", action="append", metavar="NAME:VALUE", help="Add a given HTTP header to the upload request. Can be used multiple times. For instance set 'Expires' or 'Cache-Control' headers (or both) using this option.")
 
     optparser.add_option(      "--server-side-encryption", dest="server_side_encryption", action="store_true", help="Specifies that server-side encryption will be used when putting objects.")
+    optparser.add_option(      "--sse-customer-key", dest="sse_customer_key", action="store", help="Specifies a customer provided key for server-side encryption. Must be 32 characters for AES256.")
+    optparser.add_option(      "--sse-copy-source-customer-key", dest="sse_copy_source_customer_key", action="store", help="Specifies the encryption key for copying or moving objects with a customer provided key for server-side encryption.")
 
     optparser.add_option(      "--encoding", dest="encoding", metavar="ENCODING", help="Override autodetected terminal and filesystem encoding (character set). Autodetected: %s" % preferred_encoding)
     optparser.add_option(      "--add-encoding-exts", dest="add_encoding_exts", metavar="EXTENSIONs", help="Add encoding to these comma delimited extensions i.e. (css,js,html) when uploading to S3 )")
@@ -2287,6 +2292,27 @@ def main():
         if cfg.progress_meter:
             error(u"Option --progress is not yet supported on MS Windows platform. Assuming --no-progress.")
             cfg.progress_meter = False
+
+    if options.sse_customer_key is not None:
+        cfg.sse_customer_key = options.sse_customer_key
+
+    if cfg.sse_customer_key is not None:
+        md5 = hashlib.md5()
+        md5.update(options.sse_customer_key)
+        md5_encoded = base64.b64encode(md5.digest())
+        encoded = base64.b64encode(options.sse_customer_key)
+        cfg.extra_headers["x-amz-server-side-encryption-customer-algorithm"] = "AES256"
+        cfg.extra_headers["x-amz-server-side-encryption-customer-key"] = encoded
+        cfg.extra_headers["x-amz-server-side-encryption-customer-key-md5"] = md5_encoded
+
+    if options.sse_copy_source_customer_key is not None:
+        md5 = hashlib.md5()
+        md5.update(options.sse_copy_source_customer_key)
+        md5_encoded = base64.b64encode(md5.digest())
+        encoded = base64.b64encode(options.sse_copy_source_customer_key)
+        cfg.extra_headers["x-amz-copy-source-server-side-encryption-customer-algorithm"] = "AES256"
+        cfg.extra_headers["x-amz-copy-source-server-side-encryption-customer-key"] = encoded
+        cfg.extra_headers["x-amz-copy-source-server-side-encryption-customer-key-md5"] = md5_encoded
 
     ## Pre-process --add-header's and put them to Config.extra_headers SortedDict()
     if options.add_header:

--- a/s3cmd.1
+++ b/s3cmd.1
@@ -128,7 +128,7 @@ List CloudFront distribution points
 .TP
 s3cmd \fBcfinfo\fR \fI[cf://DIST_ID]\fR
 Display CloudFront distribution point parameters
-.TP
+ .TP
 s3cmd \fBcfcreate\fR \fIs3://BUCKET\fR
 Create CloudFront distribution point
 .TP
@@ -356,6 +356,14 @@ used multiple times. For instance set 'Expires' or
 \fB\-\-server\-side\-encryption\fR
 Specifies that server-side encryption will be used
 when putting objects.
+.TP
+\fB\-\-sse\-customer\-key\fR=12345678901234567890123456789012
+Specifies a customer key for server-side encryption will be used
+when putting objects. Must be 32 characters.
+.TP
+\fB\-\-sse\-copy\-source\-customer\-key\fR=12345678901234567890123456789012
+Specifies the key for copying objects with server-side
+encryption curtomer key. Must be 32 characters.
 .TP
 \fB\-\-encoding\fR=ENCODING
 Override autodetected terminal and filesystem encoding

--- a/s3cmd.1
+++ b/s3cmd.1
@@ -358,12 +358,12 @@ Specifies that server-side encryption will be used
 when putting objects.
 .TP
 \fB\-\-sse\-customer\-key\fR=12345678901234567890123456789012
-Specifies a customer key for server-side encryption will be used
+Specifies a customer key for server-side encryption, to be used
 when putting objects. Must be 32 characters.
 .TP
 \fB\-\-sse\-copy\-source\-customer\-key\fR=12345678901234567890123456789012
 Specifies the key for copying objects with server-side
-encryption curtomer key. Must be 32 characters.
+encryption customer key. Must be 32 characters.
 .TP
 \fB\-\-encoding\fR=ENCODING
 Override autodetected terminal and filesystem encoding


### PR DESCRIPTION
Support for the recently announced Server Side Encryption with a Customer provided key (SEE-C) feature now available on Amazon S3. See the [Amazon SSE-C documentation](http://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html).

See [this wiki page](https://github.com/jheller/s3cmd/wiki) for usage, new options and caveats.
