### PR TITLE
Unbreak Config on empty options

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -223,7 +223,10 @@ class Config(object):
     def read_config_file(self, configfile):
         cp = ConfigParser(configfile)
         for option in self.option_list():
-            self.update_option(option, cp.get(option).strip())
+            _option = cp.get(option)
+            if _option is not None:
+                _option = _option.strip()
+            self.update_option(option, _option)
 
         if cp.get('add_headers'):
             for option in cp.get('add_headers').split(","):


### PR DESCRIPTION
This prevents the following issue:

Traceback (most recent call last):
  File "/usr/local/bin/s3cmd", line 2521, in <module>
    rc = main()
  File "/usr/local/bin/s3cmd", line 2261, in main
    cfg = Config(options.config, options.access_key, options.secret_key)
  File "/usr/local/lib/python2.7/dist-packages/S3/Config.py", line 126, in **init**
    self.read_config_file(configfile)
  File "/usr/local/lib/python2.7/dist-packages/S3/Config.py", line 226, in read_config_file
    self.update_option(option, cp.get(option).strip())
AttributeError: 'NoneType' object has no attribute 'strip'
