### PR TITLE
fix issue with sync and --remove-deleted on Windows. 

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1037,7 +1037,7 @@ def cmd_sync_remote2local(args):
                         response = s3.object_get(uri, dst_stream, extra_label = seq_label)
                         dst_stream.close()
                         # download completed, rename the file to destination
-                        os.rename(chkptfname, dst_file)
+                        shutil.move(chkptfname, dst_file)
                         debug(u"renamed chkptfname=%s to dst_file=%s" % (unicodise(chkptfname), unicodise(dst_file)))
                 except OSError, e:
                     if e.errno == errno.EISDIR:


### PR DESCRIPTION
fix issue with sync and --remove-deleted on Windows. Download is failed on os.rename if "cfg.delete_after == True" and file is exist but have different md5.
