### PR TITLE
Fix removeNameSpace parsing problem

### DIFF
--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -74,7 +74,7 @@ def stripNameSpace(xml):
     """
     removeNameSpace(xml) -- remove top-level AWS namespace
     """
-    r = re.compile('^(<?[^>]+?>\s?)(<\w+) xmlns=[\'"](http://[^\'"]+)[\'"](.*)', re.MULTILINE)
+    r = re.compile('^(<?[^>]+?>\s*)(<\w+) xmlns=[\'"](http://[^\'"]+)[\'"](.*)', re.MULTILINE)
     if r.match(xml):
         xmlns = r.match(xml).groups()[2]
         xml = r.sub("\\1\\2\\4", xml)


### PR DESCRIPTION
removeNameSpace cannot work correctly when there are more than one
white space after XML decaration in response message. Fix it.
