### PR TITLE
Look for config file in current working directory first

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2112,13 +2112,14 @@ def main():
     #optparser.disable_interspersed_args()
 
     config_file = None
-    if os.getenv("S3CMD_CONFIG"):
-        config_file = os.getenv("S3CMD_CONFIG")
-    elif os.name == "nt" and os.getenv("USERPROFILE"):
-        config_file = os.path.join(os.getenv("USERPROFILE").decode('mbcs'), os.getenv("APPDATA").decode('mbcs') or 'Application Data', "s3cmd.ini")
+    if os.path.isfile(os.path.join(".", ".s3cfg")):
+	  config_file = os.path.join(".", ".s3cfg")
     else:
-        from os.path import expanduser
-        config_file = os.path.join(expanduser("~"), ".s3cfg")
+      if os.getenv("HOME"):
+          config_file = os.path.join(os.getenv("HOME"), ".s3cfg")
+      elif os.name == "nt" and os.getenv("USERPROFILE"):
+          config_file = os.path.join(os.getenv("USERPROFILE").decode('mbcs'), "Application Data", "s3cmd.ini")
+
 
     preferred_encoding = locale.getpreferredencoding() or "UTF-8"
 


### PR DESCRIPTION
This allows you to use different config files without the -c option by putting them in the working folder.