### PR TITLE
Add a config parameter to enable path-style bucket access

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -113,6 +113,7 @@ class Config(object):
     expiry_days = ""
     expiry_date = ""
     expiry_prefix = ""
+    use_path_mode = False
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None):

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -441,6 +441,8 @@ def check_bucket_name(bucket, dns_strict = True):
 __all__.append("check_bucket_name")
 
 def check_bucket_name_dns_conformity(bucket):
+    if Config.Config().use_path_mode:
+        return False
     try:
         return check_bucket_name(bucket, dns_strict = True)
     except Exceptions.ParameterError:


### PR DESCRIPTION
This is a preliminary implementation of #375. I welcome any feedback, especially with regard to testing. I have checked this against run-tests.py, and see one failing test, but have not fully grokked the test suite setup just yet.
