### PR TITLE
Add Config.host_dns_compatible flag to force DNS off.

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -113,6 +113,7 @@ class Config(object):
     expiry_days = ""
     expiry_date = ""
     expiry_prefix = ""
+    host_dns_compatible = True
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None):

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -442,7 +442,10 @@ __all__.append("check_bucket_name")
 
 def check_bucket_name_dns_conformity(bucket):
     try:
-        return check_bucket_name(bucket, dns_strict = True)
+        if Config.Config().host_dns_compatible:
+            return check_bucket_name(bucket, dns_strict = True)
+        else:
+            return False
     except Exceptions.ParameterError:
         return False
 __all__.append("check_bucket_name_dns_conformity")
@@ -514,4 +517,3 @@ __all__.append("getgrgid_grpname")
 
 
 # vim:et:ts=4:sts=4:ai
-


### PR DESCRIPTION
This allows for all of us folks with internal Ceph gateways that do not
have DNS turned on to enable s3cmd to work with everything.
