### PR TITLE
Added ability to retry tests

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -12,6 +12,7 @@ import sys
 import Progress
 from SortedDict import SortedDict
 import httplib
+from socket import timeout
 try:
     import json
 except ImportError, e:
@@ -139,8 +140,19 @@ class Config(object):
                 if env_access_key:
                     self.access_key = env_access_key
                     self.secret_key = env_secret_key
-                else:
+                elif self.host_is_ec2():
                     self.role_config()
+
+    @staticmethod
+    def host_is_ec2():
+        try:
+            conn = httplib.HTTPConnection(host='169.254.169.254', timeout=2)
+            conn.request('GET', "/1.0/")
+            resp = conn.getresponse()
+            resp.read()
+        except timeout:
+            return False
+        return resp.status == 200
 
     def role_config(self):
         if sys.version_info[0] * 10 + sys.version_info[1] < 26:


### PR DESCRIPTION
Test "57  Get current expiration setting" fails every now and then, likely due to the change not being propagated quick enough in S3. Thus, I have added the ability for tests to retry when they fail. The default retry limit I have proposed is 5, and I added an exception for the test in question, raising it to 10 attempts, just in case.

As I was testing this locally, and not on EC2, I added a check in S3/Config.py so that it only tries to look for IAM role credentials when running on EC2. You get this error if you run s3cmd without any environment variables set on a non-EC2 instance. I thought it'd be better than getting a Python error relating to a socket timeout when trying to fetch IAM role credentials.

I believe that there may be a bigger issue with IAM credentials overriding the values set in ~/.s3cfg, but I am yet to write up an issue for it.
