### PR TITLE
--no-check-md5 now also affects put combined with --continue-put parameter

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -112,7 +112,8 @@ class Config(object):
     ignore_failed_copy = False
     expiry_days = ""
     expiry_date = ""
-    expiry_prefix = ""
+    expiry_prefix = "",
+    check_md5 = True
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None):

--- a/s3cmd
+++ b/s3cmd
@@ -377,7 +377,7 @@ def cmd_object_put(args):
             debug(u"attr_header: %s" % attr_header)
             extra_headers.update(attr_header)
         try:
-            response = s3.object_put(full_name, uri_final, extra_headers, extra_label = seq_label)
+            response = s3.object_put(full_name, uri_final, extra_headers, extra_label = seq_label, check_md5 = Config().check_md5)
         except S3UploadError, e:
             error(u"Upload of '%s' failed too many times. Skipping that file." % full_name_orig)
             continue
@@ -2315,9 +2315,11 @@ def main():
         try:
             cfg.sync_checks.remove("md5")
             cfg.preserve_attrs_list.remove("md5")
+            cfg.check_md5 = False
         except Exception:
             pass
     if options.check_md5 == True:
+        cfg.check_md5 = True
         if cfg.sync_checks.count("md5") == 0:
             cfg.sync_checks.append("md5")
         if cfg.preserve_attrs_list.count("md5") == 0:


### PR DESCRIPTION
Sometimes there's a need to continuously upload a file as it grows, "--continue-put" helps with that. The problem is that in some cases the file ends up being very big and thus calculating it's MD5 hash is very time consuming. In this kind of scenario one might be willing to "risk it" by not checking the MD5.
