### PR TITLE
Support proxying SSL connections

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -4,6 +4,7 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+import sys
 import httplib
 from urlparse import urlparse
 from threading import Semaphore
@@ -45,6 +46,8 @@ class ConnMan(object):
             ssl = cfg.use_https
         conn = None
         if cfg.proxy_host != "":
+            if ssl and sys.hexversion < 0x02070000:
+                raise ParameterError("use_https=True can't be used with proxy on Python <2.7")
             conn_id = "proxy://%s:%s" % (cfg.proxy_host, cfg.proxy_port)
         else:
             conn_id = "http%s://%s" % (ssl and "s" or "", hostname)

--- a/s3cmd
+++ b/s3cmd
@@ -1779,7 +1779,7 @@ def run_configure(config_file, args):
         ("secret_key", "Secret Key"),
         ("gpg_passphrase", "Encryption password", "Encryption password is used to protect your files from reading\nby unauthorized persons while in transfer to S3"),
         ("gpg_command", "Path to GPG program"),
-        ("use_https", "Use HTTPS protocol", "When using secure HTTPS protocol all communication with Amazon S3\nservers is protected from 3rd party eavesdropping. This method is\nslower than plain HTTP"),
+        ("use_https", "Use HTTPS protocol", "When using secure HTTPS protocol all communication with Amazon S3\nservers is protected from 3rd party eavesdropping. This method is\nslower than plain HTTP, and can only be proxied with Python 2.7 or newer"),
         ("proxy_host", "HTTP Proxy server name", "On some networks all internet access must go through a HTTP proxy.\nTry setting it here if you can't connect to S3 directly"),
         ("proxy_port", "HTTP Proxy server port"),
         ]
@@ -1800,6 +1800,9 @@ def run_configure(config_file, args):
             for option in options:
                 prompt = option[1]
                 ## Option-specific handling
+                if option[0] == 'proxy_host' and getattr(cfg, 'use_https') == True and sys.hexversion < 0x02070000:
+                    setattr(cfg, option[0], "")
+                    continue
                 if option[0] == 'proxy_port' and getattr(cfg, 'proxy_host') == "":
                     setattr(cfg, option[0], 0)
                     continue


### PR DESCRIPTION
In 2.7, httplib introduced support for [proxying SSL connections](https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.set_tunnel), via CONNECT.

This change removes the restriction of no SSL when using a proxy.
