### PR TITLE
Disable dns support for buckets when "host_bucket" hostname doesn't have a %(bucket)s item in it.

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -208,7 +208,7 @@ class S3(object):
         self.config = config
 
     def get_hostname(self, bucket):
-        if bucket and check_bucket_name_dns_conformity(bucket):
+        if bucket and check_bucket_name_dns_support(self.config.host_bucket, bucket):
             if self.redir_map.has_key(bucket):
                 host = self.redir_map[bucket]
             else:
@@ -222,7 +222,7 @@ class S3(object):
         self.redir_map[bucket] = redir_hostname
 
     def format_uri(self, resource):
-        if resource['bucket'] and not check_bucket_name_dns_conformity(resource['bucket']):
+        if resource['bucket'] and not check_bucket_name_dns_support(self.config.host_bucket, resource['bucket']):
             uri = "/%s%s" % (resource['bucket'], resource['uri'])
         else:
             uri = resource['uri']

--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -78,7 +78,7 @@ class S3UriS3(S3Uri):
         return u"/".join([u"s3:/", self._bucket, self._object])
 
     def is_dns_compatible(self):
-        return check_bucket_name_dns_conformity(self._bucket)
+        return check_bucket_name_dns_support(Config.Config().host_bucket, self._bucket)
 
     def public_url(self):
         if self.is_dns_compatible():

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -447,6 +447,20 @@ def check_bucket_name_dns_conformity(bucket):
         return False
 __all__.append("check_bucket_name_dns_conformity")
 
+def check_bucket_name_dns_support(bucket_host, bucket_name):
+    """
+    Check whether either the host_bucket support buckets and
+    either bucket name is dns compatible
+    """
+    if "%(bucket)s" not in bucket_host:
+        return False
+
+    try:
+        return check_bucket_name(bucket_name, dns_strict = True)
+    except Exceptions.ParameterError:
+        return False
+__all__.append("check_bucket_name_dns_support")
+
 def getBucketFromHostname(hostname):
     """
     bucket, success = getBucketFromHostname(hostname)


### PR DESCRIPTION
Here is my proposal to support S3 servers that don't support usage of dns hostname for buckets like Ceph:
In the config, currently there is the host_bucket entry that give the bucket "hostname" pattern.
Ex.: host_bucket = "%(bucket)s.s3.amazonaws.com"
With my patch, if you remove the bucket part and only use the base url like that:
Ex.: host_bucket = "s3.amazonaws.com"
Then, dns resolution will be disabled and "path-style" bucket access be used.
