### PR TITLE
Match S3 websites for CF invalidation correctly

### DIFF
--- a/S3/CloudFront.py
+++ b/S3/CloudFront.py
@@ -8,6 +8,7 @@ import sys
 import time
 import httplib
 import random
+import re
 from datetime import datetime
 from logging import debug, info, warning, error
 
@@ -584,12 +585,10 @@ class CloudFront(object):
                     #       do this since S3 buckets that are set up as websites use custom origins.
                     #       Thankfully, the custom origin URLs they use start with the URL of the
                     #       S3 bucket. Here, we make use this naming convention to support this use case.
-                    distListIndex = getBucketFromHostname(d.info['CustomOrigin']['DNSName'])[0];
-                    distListIndex = distListIndex[:len(uri.bucket())]
-                    CloudFront.dist_list[distListIndex] = d.uri()
-                else:
-                    # Aral: I'm not sure when this condition will be reached, but keeping it in there.
-                    continue
+                    m = re.match("^([^.]+)\.s3-website.+\.amazonaws\.com$", d.info['CustomOrigin']['DNSName'])
+                    if not m:
+                        continue
+                    CloudFront.dist_list[m.groups()[0]] = d.uri()
             debug("dist_list: %s" % CloudFront.dist_list)
         try:
             return CloudFront.dist_list[uri.bucket()]


### PR DESCRIPTION
Before this patch the first distribution with a custom origin that had a prefix matching the bucket would be chosen.