### PR TITLE
Support relative expiry times in signurl

### DIFF
--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -360,6 +360,9 @@ def time_to_epoch(t):
     elif isinstance(t, str) or isinstance(t, unicode):
         # See if it's a string representation of an epoch
         try:
+            # Support relative times (eg. "+60")
+            if t.startswith('+'):
+                return time.time() + int(t[1:])
             return int(t)
         except ValueError:
             # Try to parse it as a timestamp string

--- a/s3cmd
+++ b/s3cmd
@@ -1994,7 +1994,7 @@ def get_commands_list():
 
     {"cmd":"accesslog", "label":"Enable/disable bucket access logging", "param":"s3://BUCKET", "func":cmd_accesslog, "argc":1},
     {"cmd":"sign", "label":"Sign arbitrary string using the secret key", "param":"STRING-TO-SIGN", "func":cmd_sign, "argc":1},
-    {"cmd":"signurl", "label":"Sign an S3 URL to provide limited public access with expiry", "param":"s3://BUCKET/OBJECT expiry_epoch", "func":cmd_signurl, "argc":2},
+    {"cmd":"signurl", "label":"Sign an S3 URL to provide limited public access with expiry", "param":"s3://BUCKET/OBJECT <expiry_epoch|+expiry_offset>", "func":cmd_signurl, "argc":2},
     {"cmd":"fixbucket", "label":"Fix invalid file names in a bucket", "param":"s3://BUCKET[/PREFIX]", "func":cmd_fixbucket, "argc":1},
 
     ## Website commands


### PR DESCRIPTION
UNIX timestamps are annoying on the command line, eg. compare:

    $ s3cmd signurl s3://bucket/filename $(($(date +%s) + 60))

vs.

    $ s3cmd signurl s3://bucket/filename +60

Both times are still relative to the local clock of course, but at least
this is easier to read and play around with.