### PR TITLE
fix S3 wildcard certificate checking

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -52,6 +52,23 @@ class http_connection(object):
 
     @staticmethod
     def match_hostname_aws(cert, hostname, e):
+        """
+        Wildcard matching for *.s3.amazonaws.com and similar per region.
+
+        Per http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html:
+        "We recommend that all bucket names comply with DNS naming conventions."
+
+        Per http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html:
+        "When using virtual hosted-style buckets with SSL, the SSL
+        wild card certificate only matches buckets that do not contain
+        periods. To work around this, use HTTP or write your own
+        certificate verification logic."
+
+        Therefore, we need a custom validation routine that allows
+        mybucket.example.com.s3.amazonaws.com to be considered a valid
+        hostname for the *.s3.amazonaws.com wildcard cert, and for the
+        region-specific *.s3-[region].amazonaws.com wildcard cert.
+        """
         san = cert.get('subjectAltName', ())
         for key, value in san:
             if key == 'DNS':


### PR DESCRIPTION
First, the implementation had a bug, and did not actually disable the
ssl.match_hostname() check like we originally believed, because the
change to the context.check_hostname=False flag occurred too late.

Second, we want to do the hostname checking ourselves, so we can
continue when presented with an S3 wildcard certificate.  We invoke
the SSLContext.match_hostname() function for all connections, and if
it fails, we check if we're actually looking at an S3 wildcard
certificate and communicating with an S3 host. If so, this is
permissible.  If not, we fail the connection immediately.

This should resolve the concern over disabling SSL certificate
hostname checking.