### PR TITLE
Add support for display names in --acl-revoke (#223)

### DIFF
--- a/S3/ACL.py
+++ b/S3/ACL.py
@@ -179,9 +179,10 @@ class ACL(object):
         permission = permission.upper()
 
         if "ALL" == permission:
-            self.grantees = [g for g in self.grantees if not g.name.lower() == name]
+            self.grantees = [g for g in self.grantees if not (g.name.lower() == name or g.display_name.lower() == name)]
         else:
-            self.grantees = [g for g in self.grantees if not (g.name.lower() == name and g.permission.upper() ==  permission)]
+            self.grantees = [g for g in self.grantees if not ((g.display_name.lower() == name and g.permission.upper() == permission)\
+				 or (g.name.lower() == name and g.permission.upper() ==  permission))]
 
 
     def __str__(self):

--- a/s3cmd.1
+++ b/s3cmd.1
@@ -241,7 +241,7 @@ Grant stated permission to a given amazon user.
 Permission is one of: read, write, read_acp,
 write_acp, full_control, all
 .TP
-\fB\-\-acl\-revoke\fR=PERMISSION:USER_CANONICAL_ID
+\fB\-\-acl\-revoke\fR=PERMISSION:USER_CANONICAL_ID or USER_DISPLAY_NAME
 Revoke stated permission for a given amazon user.
 Permission is one of: read, write, read_acp, wr
 ite_acp, full_control, all


### PR DESCRIPTION
Current --acl-revoke only accepts user canonical ids as grantee specification.

'info' command lists users' display names in ACL entries.
Adding support for display names in --acl-revoke makes it easy to revoke
ACLs based on info command output. This alleviates problem outlined in #223