### PR TITLE
Fix for issue #432. Read the response from httplib even if there is a 0 ...

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1315,6 +1315,11 @@ class S3(object):
             progress.current_position = current_position
 
         try:
+            # Fix for issue #432. Even when content size is 0, httplib expect the response to be read.
+            if size_left == 0:
+                data = http_response.read(1)
+                # It is not supposed to be some data returned in that case
+                assert(len(data) == 0)
             while (current_position < size_total):
                 this_chunk = size_left > self.config.recv_chunk and self.config.recv_chunk or size_left
 

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1328,7 +1328,7 @@ class S3(object):
 
                 data = http_response.read(this_chunk)
                 if len(data) == 0:
-                    raise S3Error("EOF from S3!")
+                    raise S3ResponseError("EOF from S3!")
 
                 #throttle
                 if self.config.limitrate > 0:


### PR DESCRIPTION
...byte to read. So httplib doesn't think that there is a response waiting to be read when the next request come.

Straightforward to fix thanks to the detailed analysis of Edwintorok.

<<
This seems to be due to this in python 2.7.9rc1's httplib:

        if self.__state != _CS_REQ_SENT or self.__response:
            raise ResponseNotReady()

Apparently python created a response object for the content-length: 0 reply (for GET /0) and s3cmd
didn't read/close that response object, and now it gives an error when you try to read anything else on the same persistent connection.
>>

https://github.com/s3tools/s3cmd/issues/432