### PR TITLE
Ignore etag in the case of a KMS server side encryption

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1378,7 +1378,7 @@ class S3(object):
                 response["md5"] = response["headers"]["etag"]
 
         md5_hash = response["headers"]["etag"]
-        if not 'x-amz-meta-s3tools-gpgenc' in response["headers"]:
+        if (not 'x-amz-meta-s3tools-gpgenc' in response["headers"]) and (not 'x-amz-server-side-encryption-aws-kms-key-id' in response["headers"]):
             # we can't trust our stored md5 because we
             # encrypted the file after calculating it but before
             # uploading it.


### PR DESCRIPTION
According to Amazon the etag is incorrect in the case of a KMS signed server side encryption, show it should be ignored.