### PR TITLE
For copy and modify, take care to check if there is an error after the start of the operation

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1730,13 +1730,18 @@ def cmd_fixbucket(args):
                 debug("Step 3:  ... then to %s" % key_new)
                 src = S3Uri("s3://%s/%s" % (culprit.bucket(), key_bin))
                 dst = S3Uri("s3://%s/%s" % (culprit.bucket(), key_new))
-                resp_move = s3.object_move(src, dst)
-                if resp_move['status'] == 200:
-                    output("File %r renamed to %s" % (key_bin, key_new))
-                    count += 1
-                else:
+                try:
+                    resp_move = s3.object_move(src, dst)
+                    if resp_move['status'] == 200:
+                        output("File %r renamed to %s" % (key_bin, key_new))
+                        count += 1
+                    else:
+                        error("Something went wrong for: %r" % key)
+                        error("Please report the problem to s3tools-bugs@lists.sourceforge.net")
+                except S3Error:
                     error("Something went wrong for: %r" % key)
                     error("Please report the problem to s3tools-bugs@lists.sourceforge.net")
+
     if count > 0:
         warning("Fixed %d files' names. Their ACL were reset to Private." % count)
         warning("Use 's3cmd setacl --acl-public s3://...' to make")


### PR DESCRIPTION
For copy and modify, take care to check if there is an error after the start of the operation (reported by a status 200 but an "Error" root entry in the xml body)

In addition, for the move, It is good to check for the CopyObject xml reply to see if it is a success.
But, if there is a status of 200 and no "data" in response, don't fail. Other S3 server implementations use only status code and don't return any body when there is no error.

References:
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html
http://doc.s3.amazonaws.com/proposals/copy.html