### PR TITLE
Catch get_bucket_location IOError in send_file

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1032,7 +1032,18 @@ class S3(object):
         method_string, resource, headers = request.get_triplet()
         if S3Request.region_map.get(request.resource['bucket'], None) is None:
             s3_uri = S3Uri(u's3://' + request.resource['bucket'])
-            region = self.get_bucket_location(s3_uri)
+            try:
+                region = self.get_bucket_location(s3_uri)
+            except Exception, e:
+                if retries:
+                    warning("Retrying get_bucket_location: %s (%s)" % (s3_uri, e))
+                    warning("Waiting %d sec..." % self._fail_wait(retries))
+                    time.sleep(self._fail_wait(retries))
+                    # Connection error -> same throttle value
+                    return self.send_file(request, file, labels, buffer, throttle, retries - 1, offset, chunk_size)
+                else:
+                    raise S3UploadError("Get bucket location failed for: %s" % resource['uri'])
+
             if region is not None:
                 S3Request.region_map[request.resource['bucket']] = region
 


### PR DESCRIPTION
I frequently see a broken pipe, which I tracked down to get_bucket_location. This seems to happen on big syncs, where there are lots of files to compare - maybe the connection is being dropped?

Borrowing the retry code from the try block below, this simply retries the same send_file, which appears to solve the problem.

(Confession: this is the first Python I've edited / written so all feedback received gladly and I'll happily tidy up / modify, hand-over or rewrite this)