### PR TITLE
Extend the list of non printables char that have to be replaced by ^? wi...

### DIFF
--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -358,7 +358,7 @@ def replace_nonprintables(string):
         if (o <= 31):
             new_string += "^" + chr(ord('@') + o)
             modified += 1
-        elif (o == 127):
+        elif (o == 127) or (u'\ud800' <= c <= u'\udfff') or (c == u'\ufffE') or (c == u'\uffff') or (c >= u'\u110000'):
             new_string += "^?"
             modified += 1
         else:


### PR DESCRIPTION
...th the list of invalid codepoints for XML:

XML allowed chars:
[2] Char ::= [#x1-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF] /* any Unicode character, excluding the surrogate blocks, FFFE, and FFFF. */
http://stackoverflow.com/questions/730133/invalid-characters-in-xml

This could be useful as if such a character is in some file names, the file will be uploaded successfuly with that name, but then,
subsequent sync will fail (GET /) as in some calls like "list files", filenames are listed in an XML reply and so etree xml parsing
will badly fail raising a ParseError Invalid Token exception when encountering such a character.