### PR TITLE
Fixes #528 fix exception when invalid encoding with python-magic

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -36,6 +36,7 @@ from Crypto import sign_string_v2, sign_string_v4, checksum_sha256_file, checksu
 from ExitCodes import *
 
 try:
+    from ctypes import ArgumentError
     import magic
     try:
         ## https://github.com/ahupp/python-magic
@@ -83,7 +84,7 @@ def mime_magic(file):
         magictype = None
         try:
             magictype = mime_magic_file(file)
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, UnicodeEncodeError, ArgumentError):
             magictype = mime_magic_file(unicodise(file))
         return magictype
 


### PR DESCRIPTION
some magic library could report ArgumentError or UnicodeEncodeError when bad encoding is used for them.

There is a lot of different "python-magic" libraries/versions, all doing different things, so all cases need to be covered.

I hope that it will fix:
https://github.com/s3tools/s3cmd/issues/528