### PR TITLE
Modify Won't Set Reduced-Redundancy #530

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -555,6 +555,8 @@ class S3(object):
             headers["x-amz-acl"] = "public-read"
         if self.config.reduced_redundancy:
             headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        else:
+            headers["x-amz-storage-class"] = "STANDARD"
 
         ## Multipart decision
         multipart = False
@@ -724,8 +726,10 @@ class S3(object):
 
         headers['x-amz-copy-source'] = encode_to_s3("/%s/%s" % (src_uri.bucket(), self.urlencode_string(src_uri.object())))
         headers['x-amz-metadata-directive'] = "REPLACE"
-
-        # cannot change between standard and reduced redundancy with a REPLACE.
+        if self.config.reduced_redundancy:
+            headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        else:
+            headers["x-amz-storage-class"] = "STANDARD"
 
         ## Set server side encryption
         if self.config.server_side_encryption:


### PR DESCRIPTION
Task-Url: https://github.com/s3tools/s3cmd/issues/530

I (manually) tested a put with reduced-redundancy set and not set. I tested modify (switching from one class to another).

I would have added unit tests, but I'm not sure if the suite is working/maintained:

```
$ python run-tests.py
System encoding: UTF-8
Using bucket prefix: '15037-'
  1  Remove test buckets ..... OK
  2  Verify no test buckets .. OK
  3  Create one bucket (EU) .. OK
  4  Create multiple buckets . OK
  5  Invalid bucket name ..... OK
  6  Buckets list ............ OK
  7  Sync to S3 .............. FAIL  ('pattern not found: WARNING: 32 non-printable characters replaced in: crappy-file-name/non-printables ^A^B^C^D^E^F^G^H^I^J^K^L^M^N^O^P^Q^R^S^T^U^V^W^X^Y^Z^[^\\^]^^^_^? +-[\\]^<>%%"\'#{}`&?.end')
----
python2 s3cmd -c /home/15037/.s3cfg sync testsuite/ s3://15037-s3cmd-autotest-1/xyz/ --exclude demo/* --exclude *.png --no-encrypt --exclude-from testsuite/exclude.encodings
----
WARNING: 32 non-printable characters replaced in: crappy-file-name/non-printables ^A^B^C^D^E^F^G^H^I^J^K^L^M^N^O^P^Q^R^S^T^U^V^W^X^Y^Z^[^\^]^^^_^? +-[/]^<>%%"'#{}`&?.end
WARNING: Module python-magic is not available. Guessing MIME types based on file extensions.
File 'testsuite/binary/random-crap' stored as 's3://15037-s3cmd-autotest-1/xyz/binary/random-crap' (20480 bytes in 0.6 seconds, 35.36 kB/s) [1 of 19]
File 'testsuite/binary/random-crap.md5' stored as 's3://15037-s3cmd-autotest-1/xyz/binary/random-crap.md5' (46 bytes in 0.4 seconds, 117.64 B/s) [2 of 19]
File 'testsuite/blahBlah/blah.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/blahBlah/blah.txt' (5 bytes in 0.4 seconds, 12.79 B/s) [3 of 19]
File 'testsuite/checksum.tar' stored as 's3://15037-s3cmd-autotest-1/xyz/checksum.tar' (10240 bytes in 0.2 seconds, 41.25 kB/s) [4 of 19]
File 'testsuite/checksum/cksum1.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/checksum/cksum1.txt' (14 bytes in 0.4 seconds, 35.00 B/s) [5 of 19]
File 'testsuite/checksum/cksum2.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/checksum/cksum2.txt' (14 bytes in 0.5 seconds, 30.74 B/s) [6 of 19]
File 'testsuite/checksum/cksum33.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/checksum/cksum33.txt' (15 bytes in 0.5 seconds, 33.08 B/s) [7 of 19]
File 'testsuite/crappy-file-name.tar.gz' stored as 's3://15037-s3cmd-autotest-1/xyz/crappy-file-name.tar.gz' (281 bytes in 0.4 seconds, 712.45 B/s) [8 of 19]
File 'testsuite/crappy-file-name/non-printables



 +-[/]^<>%%"'#{}`&?.end' stored as 's3://15037-s3cmd-autotest-1/xyz/crappy-file-name/non-printables ^A^B^C^D^E^F^G^H^I^J^K^L^M^N^O^P^Q^R^S^T^U^V^W^X^Y^Z^[^\^]^^^_^? +-[/]^<>%%"'#{}`&?.end' (70 bytes in 0.4 seconds, 192.94 B/s) [9 of 19]
File 'testsuite/dir-test/file-dir' stored as 's3://15037-s3cmd-autotest-1/xyz/dir-test/file-dir' (9 bytes in 0.5 seconds, 19.63 B/s) [10 of 19]
File 'testsuite/etc/AtomicClockRadio.ttf' stored as 's3://15037-s3cmd-autotest-1/xyz/etc/AtomicClockRadio.ttf' (34532 bytes in 0.2 seconds, 152.31 kB/s) [11 of 19]
File 'testsuite/etc/TypeRa.ttf' stored as 's3://15037-s3cmd-autotest-1/xyz/etc/TypeRa.ttf' (56708 bytes in 0.5 seconds, 113.80 kB/s) [12 of 19]
File 'testsuite/etc/more/give-me-more.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/etc/more/give-me-more.txt' (0 bytes in 0.2 seconds, -1.00 B/s) [13 of 19]
File 'testsuite/exclude.encodings' stored as 's3://15037-s3cmd-autotest-1/xyz/exclude.encodings' (12 bytes in 0.4 seconds, 28.98 B/s) [14 of 19]
File 'testsuite/permission-tests/.svnignore' stored as 's3://15037-s3cmd-autotest-1/xyz/permission-tests/.svnignore' (98 bytes in 0.4 seconds, 240.78 B/s) [15 of 19]
File 'testsuite/permission-tests/permission-denied-dir/inaccessible.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/permission-tests/permission-denied-dir/inaccessible.txt' (13 bytes in 0.4 seconds, 31.32 B/s) [16 of 19]
WARNING: File can not be uploaded: testsuite/permission-tests/permission-denied.txt: Permission denied
File 'testsuite/single-file/single-file.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/single-file/single-file.txt' (13 bytes in 0.5 seconds, 28.52 B/s) [18 of 19]
File 'testsuite/test_rm/more/give-me-more.txt' stored as 's3://15037-s3cmd-autotest-1/xyz/test_rm/more/give-me-more.txt' (0 bytes in 0.2 seconds, -1.00 B/s) [19 of 19]
remote copy: etc/AtomicClockRadio.ttf -> test_rm/AtomicClockRadio.ttf
remote copy: etc/TypeRa.ttf -> test_rm/TypeRa.ttf
Done. Uploaded 122550 bytes in 8.4 seconds, 14.20 kB/s. Copied 2 files saving 91240 bytes transfer.

----
```