### PR TITLE
Fail silently on SIGPIPE

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2614,6 +2614,11 @@ if __name__ == '__main__':
         sys.exit(EX_BREAK)
 
     except IOError, e:
+        if e.errno == errno.EPIPE:
+            # Fail silently on SIGPIPE. This likely means we wrote to a closed
+            # pipe and user does not care for any more output.
+            sys.exit(EX_IOERR)
+
         report_exception(e)
         sys.exit(EX_IOERR)
 


### PR DESCRIPTION
If an IOError occurs due to EPIPE, i.e. writing to a closed pipe, we can ignore it instead of printing the error screen. This makes s3cmd friendlier when used with other tools like `head` or `less`.

Addresses https://github.com/s3tools/s3cmd/issues/549

XXX: Might this be masking more serious errors that could manifest as EPIPE?