### PR TITLE
Handle AWS_SESSION_TOKEN environment variable

### DIFF
--- a/S3/CloudFront.py
+++ b/S3/CloudFront.py
@@ -539,9 +539,10 @@ class CloudFront(object):
         if not headers.has_key("x-amz-date"):
             headers["x-amz-date"] = time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime())
 
-        if len(self.config.access_token)>0:
+        if self.config.used_role_config:
             self.config.role_refresh()
-            headers['x-amz-security-token']=self.config.access_token
+        if self.config.session_token:
+            headers['x-amz-security-token']=self.config.session_token
 
         signature = self.sign_request(headers)
         headers["Authorization"] = "AWS "+self.config.access_key+":"+signature

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -150,14 +150,14 @@ class Config(object):
             if env_session_token:
                 self.session_token = env_session_token
 
-            # if no creds in config or environment (or if told to explicitly), try to use an IAM role
-            if not (self.access_key and self.secret_key) or self.always_use_iam_role:
-                self.role_config()
-
             # override these if passed on the command-line
             if access_key and secret_key:
                 self.access_key = access_key
                 self.secret_key = secret_key
+
+            # if no creds in config or environment (or if told to explicitly), try to use an IAM role
+            if not (self.access_key and self.secret_key) or self.always_use_iam_role:
+                self.role_config()
 
     def role_config(self):
         self.used_role_config = True

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -293,6 +293,10 @@ class Config(object):
                 error("Config: value of option %s must have suffix m, k, or nothing, not '%s'" % (option, value))
                 return
 
+        ## access_token was renamed to session_token
+        elif option == 'access_token':
+            option = 'session_token'
+
         ## allow yes/no, true/false, on/off and 1/0 for boolean options
         elif type(getattr(Config, option)) is type(True):   # bool
             if str(value).lower() in ("true", "yes", "on", "1"):

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -107,9 +107,10 @@ class S3Request(object):
     def __init__(self, s3, method_string, resource, headers, body, params = {}):
         self.s3 = s3
         self.headers = SortedDict(headers or {}, ignore_case = True)
-        if len(self.s3.config.access_token)>0:
+        if self.s3.config.used_role_config:
             self.s3.config.role_refresh()
-            self.headers['x-amz-security-token']=self.s3.config.access_token
+        if self.s3.config.session_token:
+            self.headers['x-amz-security-token']=self.s3.config.session_token
         self.resource = resource
         self.method_string = method_string
         self.params = params

--- a/s3cmd
+++ b/s3cmd
@@ -2281,6 +2281,7 @@ def main():
     optparser.add_option(      "--limit-rate", dest="limitrate", action="store", type="string", help="Limit the upload or download speed to amount bytes per second.  Amount may be expressed in bytes, kilobytes with the k suffix, or megabytes with the m suffix")
     optparser.add_option(      "--requester-pays", dest="requester_pays", action="store_true", help="Set the REQUESTER PAYS flag for operations")
     optparser.add_option("-l", "--long-listing", dest="long_listing", action="store_true", help="Produce long listing [ls]")
+    optparser.add_option(      "--always-use-iam-role", dest="always_use_iam_role", action="store_true", help="Always get temporary credentials from the EC2 metadata service, even if credentials were present in the config or environment variables.")
 
     optparser.set_usage(optparser.usage + " COMMAND [parameters]")
     optparser.set_description('S3cmd is a tool for managing objects in '+


### PR DESCRIPTION
This allows s3cmd to be used with temporary credentials as provided by aws-cli's `aws sts get-session-token` command, which is useful if your API key is required by a policy to use MFA.