### PR TITLE
Add a link to the known issues page (on github) within the header and…

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2501,6 +2501,8 @@ def report_exception(e, msg=''):
   the latest s3cmd code from the git master
   branch found at:
     https://github.com/s3tools/s3cmd
+  and have a look at the known issues list:
+    https://github.com/s3tools/s3cmd/wiki/Common-known-issues-and-their-solutions
   If the error persists, please report the
   following lines (removing any private
   info as necessary) to:
@@ -2542,6 +2544,8 @@ def report_exception(e, msg=''):
   the latest s3cmd code from the git master
   branch found at:
     https://github.com/s3tools/s3cmd
+  and have a look at the known issues list:
+    https://github.com/s3tools/s3cmd/wiki/Common-known-issues-and-their-solutions
   If the error persists, please report the
   above lines (removing any private
   info as necessary) to:


### PR DESCRIPTION
… footer of s3cmd generated error reports.

The goal is to reduce the number of duplicated "bug reports" for known issues.

Please, feel free to also complete the following page with the most commonly encountered issues:
https://github.com/s3tools/s3cmd/wiki/Common-known-issues-and-their-solutions