### PR TITLE
Replace ignore_failed_copy with stop_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ You can increase the level of verbosity with `-v` option and if you're really ke
 
 After configuring it with `--configure` all available options are spitted into your `~/.s3cfg` file. It's a text file ready to be modified in your favourite text editor.
 
+The Transfer commands (put, get, cp, mv, and sync) continue transferring even if an object fails. If a failure occurs the failure is output to stderr and the exit status will be EX_PARTIAL (2). If the option `--stop-on-error` is specified, or the config option stop_on_error is true, the transfers stop and an appropriate error code is returned.
+
 For more information refer to the [S3cmd / S3tools homepage](http://s3tools.org).
 
 ### License

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -116,7 +116,6 @@ class Config(object):
     cache_file = ""
     add_headers = ""
     remove_headers = []
-    ignore_failed_copy = False
     expiry_days = ""
     expiry_date = ""
     expiry_prefix = ""

--- a/s3cmd
+++ b/s3cmd
@@ -754,6 +754,7 @@ def subcmd_cp_mv(args, process_fce, action_str, message):
         return EX_OK
 
     seq = 0
+    ret = EX_OK
     for key in remote_list:
         seq += 1
         seq_label = "[%d of %d]" % (seq, remote_count)
@@ -769,11 +770,12 @@ def subcmd_cp_mv(args, process_fce, action_str, message):
             if Config().acl_public:
                 info(u"Public URL is: %s" % dst_uri.public_url())
         except S3Error, e:
-            if cfg.ignore_failed_copy and e.code == "NoSuchKey":
+            if not cfg.stop_on_error and e.code == "NoSuchKey":
+                ret = EX_PARTIAL
                 warning(u"Key not found %s" % item['object_uri_str'])
             else:
                 raise
-    return EX_OK
+    return ret
 
 def cmd_cp(args):
     s3 = S3(Config())
@@ -2267,7 +2269,6 @@ def main():
     optparser.add_option(      "--include-from", dest="include_from", action="append", metavar="FILE", help="Read --include GLOBs from FILE")
     optparser.add_option(      "--rinclude", dest="rinclude", action="append", metavar="REGEXP", help="Same as --include but uses REGEXP (regular expression) instead of GLOB")
     optparser.add_option(      "--rinclude-from", dest="rinclude_from", action="append", metavar="FILE", help="Read --rinclude REGEXPs from FILE")
-    optparser.add_option(      "--ignore-failed-copy", dest="ignore_failed_copy", action="store_true", help="Don't exit unsuccessfully because of missing keys")
 
     optparser.add_option(      "--files-from", dest="files_from", action="append", metavar="FILE", help="Read list of source-file names from FILE. Use - to read from stdin.")
     optparser.add_option(      "--region", "--bucket-location", metavar="REGION", dest="bucket_location", help="Region to create bucket in. As of now the regions are: us-east-1, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1, ap-southeast-1, ap-southeast-2, sa-east-1")


### PR DESCRIPTION
This fully removes the option and switches its use to stop_on_error.
Also document the new EX_PARTIAL and use of stop_on_error in the README.

Signed-off-by: Tim Anderson <tsa@biglakesoftware.com>