### PR TITLE
move progress_meter default setting down to Config class

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -32,7 +32,7 @@ class Config(object):
     simpledb_host = "sdb.amazonaws.com"
     cloudfront_host = "cloudfront.amazonaws.com"
     verbosity = logging.WARNING
-    progress_meter = True
+    progress_meter = sys.stdout.isatty()
     progress_class = Progress.ProgressCR
     send_chunk = 64 * 1024
     recv_chunk = 64 * 1024

--- a/s3cmd
+++ b/s3cmd
@@ -2383,10 +2383,6 @@ def main():
         cfg.verbosity = options.verbosity
     logging.root.setLevel(cfg.verbosity)
 
-    ## Default to --progress on TTY devices, --no-progress elsewhere
-    ## Can be overridden by actual --(no-)progress parameter
-    cfg.update_option('progress_meter', sys.stdout.isatty())
-
     ## Unsupported features on Win32 platform
     if os.name == "nt":
         if cfg.preserve_attrs:


### PR DESCRIPTION
The `cfg.progress_meter` config setting is stomped on by the `isatty()` value. On NT it then complains that the progress meter is not available. This means we get `"Option --progress is not yet supported on MS Windows platform. Assuming --no-progress."` even if we specifically set `--no-progress`

This change makes it so the `isatty()` value is used if neither `--progress` nor `--no-progress` are specified. Otherwise, use the user-provided setting.