### PR TITLE
Avoid attempting a multipart upload with more than 10000 parts

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -90,6 +90,7 @@ class Config(object):
     mime_type = ""
     enable_multipart = True
     multipart_chunk_size_mb = 15    # MB
+    multipart_max_chunks = 10000    # Maximum chunks on AWS S3, could be different on other S3-compatible APIs
     # List of checks to be performed for 'sync'
     sync_checks = ['size', 'md5']   # 'weak-timestamp'
     # List of compiled REGEXPs

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -15,7 +15,6 @@ class MultiPartUpload(object):
     MIN_CHUNK_SIZE_MB = 5       # 5MB
     MAX_CHUNK_SIZE_MB = 5120    # 5GB
     MAX_FILE_SIZE = 42949672960 # 5TB
-    MAX_CHUNKS = 10000
 
     def __init__(self, s3, file, uri, headers_baseline = {}):
         self.s3 = s3

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -15,6 +15,7 @@ class MultiPartUpload(object):
     MIN_CHUNK_SIZE_MB = 5       # 5MB
     MAX_CHUNK_SIZE_MB = 5120    # 5GB
     MAX_FILE_SIZE = 42949672960 # 5TB
+    MAX_CHUNKS = 10000
 
     def __init__(self, s3, file, uri, headers_baseline = {}):
         self.s3 = s3

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -574,6 +574,9 @@ class S3(object):
         if self.config.enable_multipart:
             if size > self.config.multipart_chunk_size_mb * 1024 * 1024 or filename == "-":
                 multipart = True
+                total_chunks = size // ( self.config.multipart_chunk_size_mb * 1024 * 1024 )
+                if total_chunks > MultiPartUpload.MAX_CHUNKS:
+                    raise ParameterError("Chunk size %d MB results in more than %d chunks. Please increase --multipart-chunk-size-mb" % (self.config.multipart_chunk_size_mb, MultiPartUpload.MAX_CHUNKS))
         if multipart:
             # Multipart requests are quite different... drop here
             return self.send_file_multipart(file, headers, uri, size)

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -574,8 +574,7 @@ class S3(object):
         if self.config.enable_multipart:
             if size > self.config.multipart_chunk_size_mb * 1024 * 1024 or filename == "-":
                 multipart = True
-                total_chunks = size // ( self.config.multipart_chunk_size_mb * 1024 * 1024 )
-                if total_chunks > MultiPartUpload.MAX_CHUNKS:
+                if size > MultiPartUpload.MAX_CHUNKS * self.config.multipart_chunk_size_mb * 1024 * 1024:
                     raise ParameterError("Chunk size %d MB results in more than %d chunks. Please increase --multipart-chunk-size-mb" % (self.config.multipart_chunk_size_mb, MultiPartUpload.MAX_CHUNKS))
         if multipart:
             # Multipart requests are quite different... drop here

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -574,8 +574,9 @@ class S3(object):
         if self.config.enable_multipart:
             if size > self.config.multipart_chunk_size_mb * 1024 * 1024 or filename == "-":
                 multipart = True
-                if size > MultiPartUpload.MAX_CHUNKS * self.config.multipart_chunk_size_mb * 1024 * 1024:
-                    raise ParameterError("Chunk size %d MB results in more than %d chunks. Please increase --multipart-chunk-size-mb" % (self.config.multipart_chunk_size_mb, MultiPartUpload.MAX_CHUNKS))
+                if size > self.config.multipart_max_chunks * self.config.multipart_chunk_size_mb * 1024 * 1024:
+                    raise ParameterError("Chunk size %d MB results in more than %d chunks. Please increase --multipart-chunk-size-mb" % \
+                          (self.config.multipart_chunk_size_mb, self.config.multipart_max_chunks))
         if multipart:
             # Multipart requests are quite different... drop here
             return self.send_file_multipart(file, headers, uri, size)


### PR DESCRIPTION
I found the issue described here
http://sourceforge.net/p/s3tools/discussion/618865/thread/3b563258/
and have written a simple patch that avoids the unnecessary upload of a file that will fail later after a lot of wasted time and bandwidth.
PS: It is my first Python code and my first Git pull request. HTH.

