### PR TITLE
Add ability to set, get and del cors policy.

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -821,6 +821,27 @@ class S3(object):
         response = self.send_request(request)
         return response
 
+    def get_cors(self, uri):
+        request = self.create_request("BUCKET_LIST", bucket = uri.bucket(), extra = "?cors")
+        response = self.send_request(request)
+        return response['data']
+
+    def set_cors(self, uri, cors):
+        headers = {}
+        # TODO check cors is proper json string
+        headers['content-type'] = 'application/xml'
+        headers['content-md5'] = compute_content_md5(cors)
+        request = self.create_request("BUCKET_CREATE", uri = uri,
+                                      extra = "?cors", headers=headers, body = cors)
+        response = self.send_request(request)
+        return response
+
+    def delete_cors(self, uri):
+        request = self.create_request("BUCKET_DELETE", uri = uri, extra = "?cors")
+        debug(u"delete_cors(%s)" % uri)
+        response = self.send_request(request)
+        return response
+
     def set_lifecycle_policy(self, uri, policy):
         headers = SortedDict(ignore_case = True)
         headers['content-md5'] = compute_content_md5(policy)

--- a/s3cmd
+++ b/s3cmd
@@ -843,6 +843,11 @@ def cmd_info(args):
                 output(u"   policy:    %s" % policy)
             except:
                 output(u"   policy:    none")
+            try:
+                cors = s3.get_cors(uri)
+                output(u"   cors:      %s" % cors)
+            except:
+                output(u"   cors:      none")
 
             for grant in acl_grant_list:
                 output(u"   ACL:       %s: %s" % (grant['grantee'], grant['permission']))
@@ -1622,6 +1627,34 @@ def cmd_delpolicy(args):
     output(u"%s: Policy deleted" % uri)
     return EX_OK
 
+def cmd_setcors(args):
+    s3 = S3(cfg)
+    uri = S3Uri(args[1])
+    cors_file = args[0]
+    cors = open(deunicodise(cors_file), 'r').read()
+
+    if cfg.dry_run: return EX_OK
+
+    response = s3.set_cors(uri, cors)
+
+    #if retsponse['status'] == 200:
+    debug(u"response - %s" % response['status'])
+    if response['status'] == 204:
+        output(u"%s: CORS updated" % uri)
+    return EX_OK
+
+def cmd_delcors(args):
+    s3 = S3(cfg)
+    uri = S3Uri(args[0])
+    if cfg.dry_run: return EX_OK
+
+    response = s3.delete_cors(uri)
+
+    #if retsponse['status'] == 200:
+    debug(u"response - %s" % response['status'])
+    output(u"%s: CORS deleted" % uri)
+    return EX_OK
+
 def cmd_set_payer(args):
     s3 = S3(cfg)
     uri = S3Uri(args[0])
@@ -2086,6 +2119,9 @@ def get_commands_list():
 
     {"cmd":"setpolicy", "label":"Modify Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_setpolicy, "argc":2},
     {"cmd":"delpolicy", "label":"Delete Bucket Policy", "param":"s3://BUCKET", "func":cmd_delpolicy, "argc":1},
+    {"cmd":"setcors", "label":"Modify Bucket CORS", "param":"FILE s3://BUCKET", "func":cmd_setcors, "argc":2},
+    {"cmd":"delcors", "label":"Delete Bucket CORS", "param":"s3://BUCKET", "func":cmd_delcors, "argc":1},
+
     {"cmd":"payer",     "label":"Modify Bucket Requester Pays policy", "param":"s3://BUCKET", "func":cmd_set_payer, "argc":1},
     {"cmd":"multipart", "label":"Show multipart uploads", "param":"s3://BUCKET [Id]", "func":cmd_multipart, "argc":1},
     {"cmd":"abortmp",   "label":"Abort a multipart upload", "param":"s3://BUCKET/OBJECT Id", "func":cmd_abort_multipart, "argc":2},


### PR DESCRIPTION
Adds the ability to set, get and del cors policy. Based on the policy commands.

```
> s3cmd setcors test-cors-file s3://example

> s3cmd  info s3://example
s3://example (bucket):
   Location:  us-east-1
   Payer: BucketOwner
   Expiration Rule: none
   policy:    none
   cors:      <?xml version="1.0" encoding="UTF-8"?>
<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedOrigin>*</AllowedOrigin><AllowedMethod>GET</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedMethod>PUT</AllowedMethod><MaxAgeSeconds>3000</MaxAgeSeconds><AllowedHeader>*</AllowedHeader></CORSRule></CORSConfiguration>
   ACL:       accounts: READ
   ACL:       accounts: WRITE
   ACL:       accounts: READ_ACP
   ACL:       accounts: WRITE_ACP

> s3cmd delcors s3://example
s3://example/: CORS deleted

> s3cmd info s3://example
s3://example (bucket):
   Location:  us-east-1
   Payer: BucketOwner
   Expiration Rule: none
   policy:    none
   cors:      none
   ACL:       accounts: READ
   ACL:       accounts: WRITE
   ACL:       accounts: READ_ACP
   ACL:       accounts: WRITE_ACP
```

Closes #533