### PR TITLE
Add http port parameter for server connection

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -29,6 +29,7 @@ class Config(object):
     access_token = ""
     host_base = "s3.amazonaws.com"
     host_bucket = "%(bucket)s.s3.amazonaws.com"
+    host_port = 80
     simpledb_host = "sdb.amazonaws.com"
     cloudfront_host = "cloudfront.amazonaws.com"
     verbosity = logging.WARNING

--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -118,7 +118,7 @@ class http_connection(object):
                 self.c = httplib.HTTPConnection(cfg.proxy_host, cfg.proxy_port)
                 debug(u'proxied HTTPConnection(%s, %s)' % (cfg.proxy_host, cfg.proxy_port))
             else:
-                self.c = httplib.HTTPConnection(hostname)
+                self.c = httplib.HTTPConnection(hostname, cfg.host_port)
                 debug(u'non-proxied HTTPConnection(%s)' % hostname)
         else:
             if cfg.proxy_host != "":


### PR DESCRIPTION
I'm using s3cmd as client for an [ceph](http://ceph.com/) server that listents on port 8080 for HTTP connections, so I had to introduce the port setting to the config file as well as to the http connection to get it working.