### PR TITLE
report_exception: dedup message and fix indenting

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2616,7 +2616,7 @@ def main():
     return rc
 
 def report_exception(e, msg=''):
-        sys.stderr.write(u"""
+    alert = u"""
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     An unexpected error has occurred.
   Please try reproducing the error using
@@ -2629,51 +2629,36 @@ def report_exception(e, msg=''):
   following lines (removing any private
   info as necessary) to:
    s3tools-bugs@lists.sourceforge.net
-%s
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+"""
+    sys.stderr.write(alert + msg)
+    tb = traceback.format_exc(sys.exc_info())
+    try:
+        s = u' '.join([unicodise(a) for a in sys.argv])
+    except NameError:
+        s = u' '.join([(a) for a in sys.argv])
+    sys.stderr.write(u"Invoked as: %s\n" % s)
 
-""" % msg)
-        tb = traceback.format_exc(sys.exc_info())
-        try:
-            s = u' '.join([unicodise(a) for a in sys.argv])
-        except NameError:
-            s = u' '.join([(a) for a in sys.argv])
-        sys.stderr.write(u"Invoked as: %s\n" % s)
+    e_class = str(e.__class__)
+    e_class = e_class[e_class.rfind(".")+1 : -2]
+    sys.stderr.write(u"Problem: %s: %s\n" % (e_class, e))
+    try:
+        sys.stderr.write(u"S3cmd:   %s\n" % PkgInfo.version)
+    except NameError:
+        sys.stderr.write(u"S3cmd:   unknown version. Module import problem?\n")
+    sys.stderr.write(u"python:   %s\n" % sys.version)
+    sys.stderr.write(u"environment LANG=%s\n" % os.getenv("LANG"))
+    sys.stderr.write(u"\n")
+    sys.stderr.write(unicode(tb, errors="replace"))
 
-        e_class = str(e.__class__)
-        e_class = e_class[e_class.rfind(".")+1 : -2]
-        sys.stderr.write(u"Problem: %s: %s\n" % (e_class, e))
-        try:
-            sys.stderr.write(u"S3cmd:   %s\n" % PkgInfo.version)
-        except NameError:
-            sys.stderr.write(u"S3cmd:   unknown version. Module import problem?\n")
-        sys.stderr.write(u"python:   %s\n" % sys.version)
-        sys.stderr.write(u"environment LANG=%s\n" % os.getenv("LANG"))
-        sys.stderr.write(u"\n")
-        sys.stderr.write(unicode(tb, errors="replace"))
+    if type(e) == ImportError:
+        sys.stderr.write("\n")
+        sys.stderr.write("Your sys.path contains these entries:\n")
+        for path in sys.path:
+            sys.stderr.write(u"\t%s\n" % path)
+        sys.stderr.write("Now the question is where have the s3cmd modules been installed?\n")
 
-        if type(e) == ImportError:
-            sys.stderr.write("\n")
-            sys.stderr.write("Your sys.path contains these entries:\n")
-            for path in sys.path:
-                sys.stderr.write(u"\t%s\n" % path)
-            sys.stderr.write("Now the question is where have the s3cmd modules been installed?\n")
-
-        sys.stderr.write("""
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    An unexpected error has occurred.
-  Please try reproducing the error using
-  the latest s3cmd code from the git master
-  branch found at:
-    https://github.com/s3tools/s3cmd
-  and have a look at the known issues list:
-    https://github.com/s3tools/s3cmd/wiki/Common-known-issues-and-their-solutions
-  If the error persists, please report the
-  above lines (removing any private
-  info as necessary) to:
-   s3tools-bugs@lists.sourceforge.net
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-""")
+    sys.stderr.write(alert)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
For some reason the report_exception function had the 13-line error message
twice. Its body was also indented by 8 spaces, when the rest of the file uses
4.