### PR TITLE
Fix FutureWarnings from S3/AccessLog.py

### DIFF
--- a/S3/AccessLog.py
+++ b/S3/AccessLog.py
@@ -28,7 +28,7 @@ class AccessLog(object):
         self.tree.attrib['xmlns'] = "http://doc.s3.amazonaws.com/2006-03-01"
 
     def isLoggingEnabled(self):
-        return bool(self.tree.find(".//LoggingEnabled"))
+        return (self.tree.find(".//LoggingEnabled") is not None)
 
     def disableLogging(self):
         el = self.tree.find(".//LoggingEnabled")
@@ -54,7 +54,7 @@ class AccessLog(object):
 
     def setAclPublic(self, acl_public):
         le = self.tree.find(".//LoggingEnabled")
-        if not le:
+        if le is None:
             raise ParameterError("Logging not enabled, can't set default ACL for logs")
         tg = le.find(".//TargetGrants")
         if not acl_public:


### PR DESCRIPTION
s3cmd accesslog command would throw these warnings:

S3/AccessLog.py:57: FutureWarning: The
behavior of this method will change in future versions.  Use specific
'len(elem)' or 'elem is not None' test instead.
  if not le:

S3/AccessLog.py:31: FutureWarning: The
behavior of this method will change in future versions.  Use
specific 'len(elem)' or 'elem is not None' test instead.
  return bool(self.tree.find(".//LoggingEnabled"))

Fix these to use 'is not None' or 'is None' instead.