### PR TITLE
add --storage-class option

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -103,6 +103,7 @@ class Config(object):
     urlencoding_mode = "normal"
     log_target_prefix = ""
     reduced_redundancy = False
+    storage_class = ""
     follow_symlinks = False
     socket_timeout = 300
     invalidate_on_cf = False

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -246,6 +246,16 @@ class S3(object):
         self.fallback_to_signature_v2 = False
         self.endpoint_requires_signature_v4 = False
 
+    def storage_class(self):
+        # Note - you cannot specify GLACIER here
+        # https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html
+        cls = 'STANDARD'
+        if self.config.storage_class != "":
+            return self.config.storage_class
+        if self.config.reduced_redundancy:
+            cls = 'REDUCED_REDUNDANCY'
+        return cls
+
     def get_hostname(self, bucket):
         if bucket and check_bucket_name_dns_support(self.config.host_bucket, bucket):
             if self.redir_map.has_key(bucket):
@@ -569,8 +579,7 @@ class S3(object):
         ## Other Amazon S3 attributes
         if self.config.acl_public:
             headers["x-amz-acl"] = "public-read"
-        if self.config.reduced_redundancy:
-            headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
+        headers["x-amz-storage-class"] = self.storage_class()
 
         ## Multipart decision
         multipart = False
@@ -709,10 +718,8 @@ class S3(object):
         headers['x-amz-metadata-directive'] = "COPY"
         if self.config.acl_public:
             headers["x-amz-acl"] = "public-read"
-        if self.config.reduced_redundancy:
-            headers["x-amz-storage-class"] = "REDUCED_REDUNDANCY"
-        else:
-            headers["x-amz-storage-class"] = "STANDARD"
+
+        headers["x-amz-storage-class"] = self.storage_class()
 
         ## Set server side encryption
         if self.config.server_side_encryption:

--- a/s3cmd
+++ b/s3cmd
@@ -2379,7 +2379,7 @@ def main():
     optparser.add_option(      "--region", "--bucket-location", metavar="REGION", dest="bucket_location", help="Region to create bucket in. As of now the regions are: us-east-1, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-northeast-1, ap-southeast-1, ap-southeast-2, sa-east-1")
     optparser.add_option(      "--reduced-redundancy", "--rr", dest="reduced_redundancy", action="store_true", help="Store object with 'Reduced redundancy'. Lower per-GB price. [put, cp, mv]")
     optparser.add_option(      "--no-reduced-redundancy", "--no-rr", dest="reduced_redundancy", action="store_false", help="Store object without 'Reduced redundancy'. Higher per-GB price. [put, cp, mv]")
-
+    optparser.add_option(      "--storage-class", dest="storage_class", action="store", metavar="CLASS", help="Store object with specified CLASS (STANDARD, STANDARD_IA, or REDUCED_REDUNDANCY). Lower per-GB price. [put, cp, mv]")
     optparser.add_option(      "--access-logging-target-prefix", dest="log_target_prefix", help="Target prefix for access logs (S3 URI) (for [cfmodify] and [accesslog] commands)")
     optparser.add_option(      "--no-access-logging", dest="log_target_prefix", action="store_false", help="Disable access logging (for [cfmodify] and [accesslog] commands)")
 


### PR DESCRIPTION
This allows us to use the newly announced STANDARD_IA class, as well
as STANDARD or REDUCED_REDUNDANCY.  This effectively deprecates
--[no-]reduced-redundancy options.  If both are specified,
--storage-class wins.

If the user specifes an invalid class, they will get an error:

S3 error: 400 (InvalidStorageClass): The storage class you specified
is not valid