### PR TITLE
Allow --requester-pays for PUT commands too (#585)

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -128,9 +128,8 @@ class S3Request(object):
         self.requester_pays()
 
     def requester_pays(self):
-        if self.method_string == "GET" or self.method_string == "POST":
-            if self.s3.config.requester_pays:
-                self.headers['x-amz-request-payer'] = 'requester'
+        if self.s3.config.requester_pays and self.method_string in ("GET", "POST", "PUT"):
+            self.headers['x-amz-request-payer'] = 'requester'
 
     def update_timestamp(self):
         if self.headers.has_key("date"):


### PR DESCRIPTION
Needed for copying content from requester-pays buckets into other
buckets.