### PR TITLE
Fix for #634. Partial get start position was dropped

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1363,7 +1363,7 @@ class S3(object):
             redir_hostname = getTextFromXml(response['data'], ".//Endpoint")
             self.set_hostname(redir_bucket, redir_hostname)
             info("Redirected to: %s" % (redir_hostname))
-            return self.recv_file(request, stream, labels)
+            return self.recv_file(request, stream, labels, start_position)
 
         if response["status"] == 400:
             return self._http_400_handler(request, response, self.recv_file, request, stream, labels, start_position)

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1366,9 +1366,9 @@ class S3(object):
             return self.recv_file(request, stream, labels)
 
         if response["status"] == 400:
-            return self._http_400_handler(request, response, self.recv_file, request, stream, labels)
+            return self._http_400_handler(request, response, self.recv_file, request, stream, labels, start_position)
         if response["status"] == 403:
-            return self._http_403_handler(request, response, self.recv_file, request, stream, labels)
+            return self._http_403_handler(request, response, self.recv_file, request, stream, labels, start_position)
         if response["status"] == 405: # Method Not Allowed.  Don't retry.
             raise S3Error(response)
 


### PR DESCRIPTION
The `recv_file` would drop the start_position if it needed to pass the request to 400 or 403 fallback handlers.