### PR TITLE
FIX the command error of s3cmd info

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -376,17 +376,23 @@ class S3(object):
         elif location == "EU":
             location = "eu-west-1"
         return location
-
+    
     def get_bucket_requester_pays(self, uri):
         request = self.create_request("BUCKET_LIST", bucket = uri.bucket(), extra = "?requestPayment")
-        response = self.send_request(request)
-        payer = getTextFromXml(response['data'], "Payer")
+        try:
+            response = self.send_request(request)
+            payer = getTextFromXml(response['data'], "Payer")
+        except S3Error, e:
+            if e.status == 403:
+                return None
         return payer
 
     def bucket_info(self, uri):
         response = {}
         response['bucket-location'] = self.get_bucket_location(uri)
         response['requester-pays'] = self.get_bucket_requester_pays(uri)
+        if response['requester-pays'] == None:
+            response['requester-pays'] = 'none'
         return response
 
     def website_info(self, uri, bucket_location = None):

--- a/s3cmd
+++ b/s3cmd
@@ -854,7 +854,7 @@ def cmd_info(args):
                 info = s3.bucket_info(uri)
                 output(u"%s (bucket):" % uri.uri())
                 output(u"   Location:  %s" % info['bucket-location'])
-                output(u"   Payer: %s" % info['requester-pays'])
+                output(u"   Payer:     %s" % info['requester-pays'])
                 try:
                     expiration = s3.expiration_info(uri, cfg.bucket_location)
                     expiration_desc = "Expiration Rule: "


### PR DESCRIPTION
If the get_bucket_requester_pays(self, uri) function fails, "s3cmd info s3://buckets" also fails when s3cmd is used in ceph

Signed-off-by: Qiankun Zheng <zheng.qiankun@h3c.com>