### PR TITLE
Disable hostname checks for SSL connections on RHEL 7.2

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -123,7 +123,12 @@ class http_connection(object):
                 context.check_hostname = False
             conn = httplib.HTTPSConnection(hostname, port, context=context, check_hostname=False)
         except TypeError:
-            conn = httplib.HTTPSConnection(hostname, port)
+            try:
+                # in case check_hostname parameter is not present try again
+                conn = httplib.HTTPSConnection(hostname, port, context=context)
+            except TypeError:
+                # in case even context parameter is not present try one last time
+                conn = httplib.HTTPSConnection(hostname, port)
         return conn
 
     def __init__(self, id, hostname, ssl, cfg):

--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -121,7 +121,7 @@ class http_connection(object):
                 # back.  We then run the same check, relaxed for S3's
                 # wildcard certificates.
                 context.check_hostname = False
-            conn = httplib.HTTPSConnection(hostname, port, context=context)
+            conn = httplib.HTTPSConnection(hostname, port, context=context, check_hostname=False)
         except TypeError:
             conn = httplib.HTTPSConnection(hostname, port)
         return conn


### PR DESCRIPTION
In RHEL 7.2 python-libs-2.7.5-34.el7.x86_64 introduced the following change:

```
diff -u httplib.py /usr/lib64/python2.7/httplib.py
--- httplib.py	2014-02-11 14:46:38.000000000 +0200
+++ /usr/lib64/python2.7/httplib.py	2015-11-24 16:33:57.106008991 +0200
@@ -215,6 +215,10 @@
 # maximal line length when calling readline().
 _MAXLINE = 65536
 
+# maximum amount of headers accepted
+_MAXHEADERS = 100
+
+
 class HTTPMessage(mimetools.Message):
 
     def addheader(self, key, value):
@@ -271,6 +275,8 @@
         elif self.seekable:
             tell = self.fp.tell
         while True:
+            if len(hlist) > _MAXHEADERS:
+                raise HTTPException("got more than %d headers" % _MAXHEADERS)
             if tell:
                 try:
                     startofline = tell()
@@ -1159,21 +1165,44 @@
 
         def __init__(self, host, port=None, key_file=None, cert_file=None,
                      strict=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
-                     source_address=None):
+                     source_address=None, context=None, check_hostname=None):
             HTTPConnection.__init__(self, host, port, strict, timeout,
                                     source_address)
             self.key_file = key_file
             self.cert_file = cert_file
+            if context is None:
+                context = ssl._create_default_https_context()
+            will_verify = context.verify_mode != ssl.CERT_NONE
+            if check_hostname is None:
+                check_hostname = will_verify
+            elif check_hostname and not will_verify:
+                raise ValueError("check_hostname needs a SSL context with "
+                                 "either CERT_OPTIONAL or CERT_REQUIRED")
+            if key_file or cert_file:
+                context.load_cert_chain(cert_file, key_file)
+            self._context = context
+            self._check_hostname = check_hostname
 
         def connect(self):
             "Connect to a host on a given (SSL) port."
 
-            sock = socket.create_connection((self.host, self.port),
-                                            self.timeout, self.source_address)
+            HTTPConnection.connect(self)
+
             if self._tunnel_host:
-                self.sock = sock
-                self._tunnel()
-            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file)
+                server_hostname = self._tunnel_host
+            else:
+                server_hostname = self.host
+            sni_hostname = server_hostname if ssl.HAS_SNI else None
+
+            self.sock = self._context.wrap_socket(self.sock,
+                                                  server_hostname=sni_hostname)
+            if not self._context.check_hostname and self._check_hostname:
+                try:
+                    ssl.match_hostname(self.sock.getpeercert(), server_hostname)
+                except Exception:
+                    self.sock.shutdown(socket.SHUT_RDWR)
+                    self.sock.close()
+                    raise
 
     __all__.append("HTTPSConnection")
```

which causes SSL connections to attempt verification of hostname, which in turn fails and causes #647. With this patch both context.check_hostname and check_hostname are set to False which successfully disables this check.

Please build an updated RPM for EPEL once this is included in master. Thanks!

Btw without this patch test 68  List all was failing on RHEL 7.2, now everything is PASS.
