### PR TITLE
Allow acl_public = True/False to be in config file #606

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -253,6 +253,11 @@ class Config(object):
                 _option = _option.strip()
             self.update_option(option, _option)
 
+        # allow acl_public to be set from the config file too, even though by
+        # default it is set to None, and not present in the config file.
+        if cp.get('acl_public'):
+            self.update_option('acl_public', cp.get('acl_public'))
+
         if cp.get('add_headers'):
             for option in cp.get('add_headers').split(","):
                 (key, value) = option.split(':')

--- a/s3cmd
+++ b/s3cmd
@@ -2726,7 +2726,8 @@ def main():
 
     ## Special handling for tri-state options (True, False, None)
     cfg.update_option("enable", options.enable)
-    cfg.update_option("acl_public", options.acl_public)
+    if options.acl_public is not None:
+        cfg.update_option("acl_public", options.acl_public)
 
     ## Check multipart chunk constraints
     if cfg.multipart_chunk_size_mb < MultiPartUpload.MIN_CHUNK_SIZE_MB:


### PR DESCRIPTION
Normally acl_public = None and it's not present, nor read from,
the config file.  If a user wants to set it in the config file though,
we need to be able to read it from the config file.

We also need to _not_ have the lack of command line options
unintentionally set it back to None.

Add special handling for acl_public, when reading in the
config file, and when handling --acl-public and --acl-private options.