### PR TITLE
Let Makefile determine version number from PkgInfo.py file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION := 1.5.0
 SHELL  := /bin/bash
+VERSION := $(shell /usr/bin/env python2 -c 'from S3 import PkgInfo;print PkgInfo.version')
 SPEC   := s3cmd.spec
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell git rev-parse --short=8 HEAD)


### PR DESCRIPTION
Currently, the Makefile has a hard-coded version number. If you run "make git-rpm" without editing the Makefile, the RPM version may not be the same the s3cmd version. However, it is easy to allow the Makefile to extract the version from the PkgInfo.py file.