### PR TITLE
Add CLI option for specifying access_token

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -132,12 +132,12 @@ class Config(object):
     stats = False
 
     ## Creating a singleton
-    def __new__(self, configfile = None, access_key=None, secret_key=None):
+    def __new__(self, configfile = None, access_key=None, secret_key=None, access_token=None):
         if self._instance is None:
             self._instance = object.__new__(self)
         return self._instance
 
-    def __init__(self, configfile = None, access_key=None, secret_key=None):
+    def __init__(self, configfile = None, access_key=None, secret_key=None, access_token=None):
         if configfile:
             try:
                 self.read_config_file(configfile)
@@ -149,6 +149,9 @@ class Config(object):
             if access_key and secret_key:
                 self.access_key = access_key
                 self.secret_key = secret_key
+
+            if access_token:
+                self.access_token = access_token
 
             if len(self.access_key)==0:
                 env_access_key = os.environ.get("AWS_ACCESS_KEY", None) or os.environ.get("AWS_ACCESS_KEY_ID", None)

--- a/s3cmd
+++ b/s3cmd
@@ -2147,6 +2147,7 @@ def run_configure(config_file, args):
     options = [
         ("access_key", "Access Key", "Access key and Secret key are your identifiers for Amazon S3. Leave them empty for using the env variables."),
         ("secret_key", "Secret Key"),
+        ("access_token", "Access Token"),
         ("bucket_location", "Default Region"),
         ("gpg_passphrase", "Encryption password", "Encryption password is used to protect your files from reading\nby unauthorized persons while in transfer to S3"),
         ("gpg_command", "Path to GPG program"),
@@ -2503,6 +2504,7 @@ def main():
     optparser.add_option(      "--dump-config", dest="dump_config", action="store_true", help="Dump current configuration after parsing config files and command line options and exit.")
     optparser.add_option(      "--access_key", dest="access_key", help="AWS Access Key")
     optparser.add_option(      "--secret_key", dest="secret_key", help="AWS Secret Key")
+    optparser.add_option(      "--access_token", dest="access_token", help="AWS Access Token")
 
     optparser.add_option("-n", "--dry-run", dest="dry_run", action="store_true", help="Only show what should be uploaded or downloaded but don't actually do it. May still perform S3 requests to get bucket listings and other information though (only for file transfer commands)")
 
@@ -2650,7 +2652,7 @@ def main():
         sys.exit(EX_CONFIG)
 
     try:
-        cfg = Config(options.config, options.access_key, options.secret_key)
+        cfg = Config(options.config, options.access_key, options.secret_key, options.access_token)
     except IOError, e:
         if options.run_configure:
             cfg = Config()


### PR DESCRIPTION
Add CLI option for specifying access_token, currently only .s3cfg config file had this option. 
My use case required us to pass the token as a CLI option along with access, secret key as the temp creds were generated on the fly for use with s3cmd.

It will be nice to have support for this. Can someone please review and get this merged?