### PR TITLE
Adding traceback message to ImportError

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2885,7 +2885,9 @@ def report_exception(e, msg=u''):
             sys.stderr.write("Your sys.path contains these entries:\n")
             for path in sys.path:
                 sys.stderr.write(u"\t%s\n" % path)
-            sys.stderr.write("Now the question is where have the s3cmd modules been installed?\n")
+            sys.stderr.write("Now the question is where have the s3cmd modules been installed?\n\n")
+            sys.stderr.write("Loading files from:\n")
+            sys.stderr.write(unicode(tb, errors="replace"))
 
         sys.stderr.write(alert_header % (u"above lines", u""))
 


### PR DESCRIPTION
Displaying traceback on an ImportError helps to determine what location s3cmd is pulling libraries from in cases where there are multiple libraries installed accidentally.
