### PR TITLE
Do not close stdout, it might be used when file is downloaded

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2639,7 +2639,6 @@ def main():
     if options.quiet:
         try:
             f = open("/dev/null", "w")
-            sys.stdout.close()
             sys.stdout = f
         except IOError:
             warning(u"Unable to open /dev/null: --quiet disabled.")


### PR DESCRIPTION
If you try downloading file with -q and destination is -, you'll receive such errors:
```
s3cmd -q get s3://some-bucket/somefile - > /dev/null
WARNING: Retrying failed request: somefile (I/O operation on closed file)
```

I do not think it is actually very good solution, actually all logging should be done through some logging wrapper, this way there won't be a need to mangle with stdout...