### PR TITLE
Added marker support to CloudFront.py to retrieve the next page of di…

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2596,6 +2596,7 @@ def main():
     optparser.add_option(      "--cf-remove-cname", dest="cf_cnames_remove", action="append", metavar="CNAME", help="Remove given CNAME from a CloudFront distribution (only for [cfmodify] command)")
     optparser.add_option(      "--cf-comment", dest="cf_comment", action="store", metavar="COMMENT", help="Set COMMENT for a given CloudFront distribution (only for [cfcreate] and [cfmodify] commands)")
     optparser.add_option(      "--cf-default-root-object", dest="cf_default_root_object", action="store", metavar="DEFAULT_ROOT_OBJECT", help="Set the default root object to return when no object is specified in the URL. Use a relative path, i.e. default/index.html instead of /default/index.html or s3://bucket/default/index.html (only for [cfcreate] and [cfmodify] commands)")
+    optparser.add_option(      "--cf-marker", dest="cf_marker", action="store", metavar="MARKER", help="Get next page when list of cloudfront distributions is a multilist list (only for [cflist] command)")
     optparser.add_option("-v", "--verbose", dest="verbosity", action="store_const", const=logging.INFO, help="Enable verbose output.")
     optparser.add_option("-d", "--debug", dest="verbosity", action="store_const", const=logging.DEBUG, help="Enable debug output.")
     optparser.add_option(      "--version", dest="show_version", action="store_true", help="Show s3cmd version (%s) and exit." % (PkgInfo.version))


### PR DESCRIPTION
Added marker support to CloudFront.py to retrieve the next page of distributions for cflist. Will show the current and next marker as well as maximum items and item count before displaying the cloudfront list. This is concerning the s3cmd cflist command.