### PR TITLE
Generalize wildcard certificate forgiveness

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -14,6 +14,7 @@ from logging import debug
 
 from Config import Config
 from Exceptions import ParameterError
+from Utils import getBucketFromHostname
 
 if not 'CertificateError ' in ssl.__dict__:
     class CertificateError(Exception):
@@ -71,7 +72,7 @@ class http_connection(object):
         http_connection.context_set = True
         return context
 
-    def match_hostname_aws(self, cert, e):
+    def forgive_wildcard_cert(self, cert, e):
         """
         Wildcard matching for *.s3.amazonaws.com and similar per region.
 
@@ -89,13 +90,11 @@ class http_connection(object):
         hostname for the *.s3.amazonaws.com wildcard cert, and for the
         region-specific *.s3-[region].amazonaws.com wildcard cert.
         """
-        debug(u'checking SSL subjectAltName against amazonaws.com')
+        debug(u'checking SSL subjectAltName as forgiving wildcard cert')
         san = cert.get('subjectAltName', ())
         for key, value in san:
             if key == 'DNS':
-                if value.startswith('*.s3') and \
-                   (value.endswith('.amazonaws.com') and self.hostname.endswith('.amazonaws.com')) or \
-                   (value.endswith('.amazonaws.com.cn') and self.hostname.endswith('.amazonaws.com.cn')):
+                if value == '*.' + Config.host_base and self.hostname.endswith("." + Config.host_base):
                     return
         raise e
 
@@ -108,20 +107,21 @@ class http_connection(object):
         except ValueError: # empty SSL cert means underlying SSL library didn't validate it, we don't either.
             return
         except ssl.CertificateError, e:
-            self.match_hostname_aws(cert, e)
+            self.forgive_wildcard_cert(cert, e)
 
     @staticmethod
     def _https_connection(hostname, port=None):
         check_hostname = True
         try:
             context = http_connection._ssl_context()
-            # S3's wildcart certificate doesn't work with DNS-style named buckets.
-            if (hostname.endswith('.amazonaws.com') or hostname.endswith('.amazonaws.com.cn')):
+            # Wilcard certificates do not work with DNS-style named buckets.
+            bucket_name, _ = getBucketFromHostname(hostname)
+            if ('.' in bucket_name):
                 # this merely delays running the hostname check until
                 # after the connection is made and we get control
                 # back.  We then run the same check, relaxed for S3's
                 # wildcard certificates.
-                debug(u'Recognized AWS S3 host, disabling initial SSL hostname check')
+                debug(u'Bucket name contains "." character, disabling initial SSL hostname check')
                 check_hostname = False
                 if context:
                     context.check_hostname = False


### PR DESCRIPTION
As the issue of wildcard certificate matching failures for DNS-style bucket names (i.e. those which contain the `.` character) also expresses itself for other S3-compatible services, the code that checks specifically for `amazonaws.com` has been replaced with a more general approach that checks for the `.` character.

Refs #437.
