### PR TITLE
Add Transition to info cmd and add getlifecycle for full xml lifecycle

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -445,6 +445,23 @@ class S3(object):
 
         return response
 
+    def transition_info(self, uri, bucket_location = None):
+        bucket = uri.bucket()
+
+        request = self.create_request("BUCKET_LIST", bucket = bucket, extra="?lifecycle")
+        try:
+            response = self.send_request(request)
+            response['prefix'] = getTextFromXml(response['data'], ".//Rule//Prefix")
+            response['date'] = getTextFromXml(response['data'], ".//Rule//Transition//Date")
+            response['days'] = getTextFromXml(response['data'], ".//Rule//Transition//Days")
+            response['StorageClass'] = getTextFromXml(response['data'], ".//Rule//Transition//StorageClass")
+            return response
+        except S3Error, e:
+            if e.status == 404:
+                debug("Could not get /?lifecycle - lifecycle probably not configured for this bucket")
+                return None
+            raise
+
     def expiration_info(self, uri, bucket_location = None):
         bucket = uri.bucket()
 
@@ -916,6 +933,14 @@ class S3(object):
         request = self.create_request("BUCKET_CREATE", uri = uri,
                                       extra = "?requestPayment", body = body)
         response = self.send_request(request)
+        return response
+
+    def get_lifecycle_policy(self, uri):
+        request = self.create_request("BUCKET_LIST", bucket = uri.bucket(), extra = "?lifecycle")
+        debug(u"get_lifecycle_policy(%s)" % uri)
+        response = self.send_request(request)
+
+        debug(u"%s: Got Lifecycle Policy" % response['status'])
         return response
 
     def delete_lifecycle_policy(self, uri):

--- a/s3cmd
+++ b/s3cmd
@@ -872,6 +872,21 @@ def cmd_info(args):
                 output(u"   Location:  %s" % info['bucket-location'])
                 output(u"   Payer:     %s" % info['requester-pays'])
                 try:
+                    transition = s3.transition_info(uri, cfg.bucket_location)
+                    transition_desc = "Transition Rule: "
+                    if transition['prefix'] == "":
+                        transition_desc += "all objects in this bucket "
+                    else:
+                        transition_desc += "objects with key prefix '" + transition['prefix'] + "' "
+                    transition_desc += "will transition to '" + transition['StorageClass'] + "' in '" 
+                    if transition['days']:
+                        transition_desc += transition['days'] + "' day(s) after creation"
+                    elif transition['date']:
+                        transition_desc += transition['date'] + "' "
+                    output(u"   %s" % transition_desc)
+                except:
+                    output(u"   Transition Rule: none")
+                try:
                     expiration = s3.expiration_info(uri, cfg.bucket_location)
                     expiration_desc = "Expiration Rule: "
                     if expiration['prefix'] == "":
@@ -1921,6 +1936,17 @@ def cmd_setlifecycle(args):
         output(u"%s: Lifecycle Policy updated" % uri)
     return EX_OK
 
+def cmd_getlifecycle(args):
+    s3 = S3(cfg)
+    uri = S3Uri(args[0])
+    if cfg.dry_run: return EX_OK
+
+    response = s3.get_lifecycle_policy(uri)
+
+    output(u"%s: Got Lifecycle Policy" % response['status'])
+    output(u"%s" % response['data'])
+    return EX_OK
+
 def cmd_dellifecycle(args):
     s3 = S3(cfg)
     uri = S3Uri(args[0])
@@ -2378,6 +2404,7 @@ def get_commands_list():
     ## Lifecycle commands
     {"cmd":"expire", "label":"Set or delete expiration rule for the bucket", "param":"s3://BUCKET", "func":cmd_expiration_set, "argc":1},
     {"cmd":"setlifecycle", "label":"Upload a lifecycle policy for the bucket", "param":"FILE s3://BUCKET", "func":cmd_setlifecycle, "argc":2},
+    {"cmd":"getlifecycle", "label":"Get a lifecycle policy for the bucket",    "param":"s3://BUCKET", "func":cmd_getlifecycle, "argc":1},
     {"cmd":"dellifecycle", "label":"Remove a lifecycle policy for the bucket", "param":"s3://BUCKET", "func":cmd_dellifecycle, "argc":1},
 
     ## CloudFront commands


### PR DESCRIPTION
Added 'Transistion' line to 'info' cmd and created new 'getlifecycle' cmd for full xml output of lifecycle.
Example output for 'info' cmd:

```
$> s3cmd info s3://sample.bucket.backups
s3://sample.bucket.backups/ (bucket):
   Location:  us-east-1
   Payer:     BucketOwner
   Transition Rule: all objects in this bucket will transition to 'GLACIER' in '8' day(s) after creation
   Expiration Rule: all objects in this bucket will expire in '373' day(s) after creation
   policy:    none
   cors:      none
   ACL:      sampleUser: FULL_CONTROL
```

based on orig work of [kuenishi](https://github.com/kuenishi): [pull req. 393](https://github.com/s3tools/s3cmd/pull/393)