### PR TITLE
Missing etag in HTTP headers, handle gracefully.

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1304,7 +1304,8 @@ class S3(object):
 
         debug("MD5 sums: computed=%s, received=%s" % (md5_computed, response["headers"]["etag"]))
         ## when using KMS encryption, MD5 etag value will not match
-        if (response["headers"]["etag"].strip('"\'') != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
+        md5_from_s3 = response["headers"].get("etag", "").strip('"\'')
+        if (md5_from_s3 != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
             warning("MD5 Sums don't match!")
             if retries:
                 warning("Retrying upload of %s" % (filename))
@@ -1473,7 +1474,7 @@ class S3(object):
             progress.update()
             progress.done("done")
 
-        md5_from_s3 = response["headers"]["etag"].strip('"')
+        md5_from_s3 = response["headers"].get("etag", "").strip('"')
         if not 'x-amz-meta-s3tools-gpgenc' in response["headers"]:
             # we can't trust our stored md5 because we
             # encrypted the file after calculating it but before

--- a/s3cmd
+++ b/s3cmd
@@ -855,7 +855,7 @@ def cmd_info(args):
                 output(u"   Last mod:  %s" % info['headers']['last-modified'])
                 output(u"   MIME type: %s" % info['headers'].get('content-type', 'none'))
                 output(u"   Storage:   %s" % info['headers'].get('x-amz-storage-class', 'STANDARD'))
-                md5 = info['headers']['etag'].strip('"\'')
+                md5 = info['headers'].get('etag', '').strip('"\'')
                 try:
                     md5 = info['s3cmd-attrs']['md5']
                 except KeyError:


### PR DESCRIPTION
If 'etag' is missing do not crash 's3cmd',  throw a warning and handle it gracefully. 