### PR TITLE
Fix Issue #672

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -500,6 +500,10 @@ class S3(object):
             raise ParameterError("You must specify --mime-type or --default-mime-type for files uploaded from stdin.")
 
         if self.config.guess_mime_type:
+            if self.config.follow_symlinks:
+                if os.path.islink(deunicodise(filename)):
+                    filename = os.path.realpath(deunicodise(filename))
+
             if self.config.use_mime_magic:
                 (content_type, content_charset) = mime_magic(filename)
             else:


### PR DESCRIPTION
With --follow-links, the target of symlinks should have the mime-type of the file they point to, not of the symlink. Dereference the link before guessing its mime-type.