### PR TITLE
Catch 'connection reset by peer' (errno 104) and retry

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1100,7 +1100,7 @@ class S3(object):
         except CertificateError:
             raise
         except (IOError, Exception), e:
-            if hasattr(e, 'errno') and e.errno != errno.EPIPE:
+            if hasattr(e, 'errno') and e.errno not in (errno.EPIPE, errno.ECONNRESET):
                 raise
             # close the connection and re-establish
             conn.counter = ConnMan.conn_max_counter
@@ -1366,7 +1366,7 @@ class S3(object):
         except (IOError, Exception), e:
             if self.config.progress_meter:
                 progress.done("failed")
-            if hasattr(e, 'errno') and e.errno != errno.EPIPE:
+            if hasattr(e, 'errno') and e.errno not in (errno.EPIPE, errno.ECONNRESET):
                 raise
             # close the connection and re-establish
             conn.counter = ConnMan.conn_max_counter
@@ -1449,7 +1449,7 @@ class S3(object):
         except (IOError, Exception), e:
             if self.config.progress_meter:
                 progress.done("failed")
-            if hasattr(e, 'errno') and e.errno != errno.EPIPE:
+            if hasattr(e, 'errno') and e.errno not in (errno.EPIPE, errno.ECONNRESET):
                 raise
             # close the connection and re-establish
             conn.counter = ConnMan.conn_max_counter


### PR DESCRIPTION
S3 occasionally closes our connection unexpectedly.  We weren't
catching this, but would crash with a traceback when it happens.

Explicitly catch and retry on ECONNRESET.