### PR TITLE
Handle missing ETag in subcmd_bucket_list

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -173,7 +173,7 @@ def subcmd_bucket_list(s3, uri):
             "uri": uri.compose_uri(bucket, prefix["Prefix"])})
 
     for object in response["list"]:
-        md5 = object['ETag'].strip('"\'')
+        md5 = object.get('ETag', '').strip('"\'')
         storageclass = object.get('StorageClass','')
 
         if cfg.list_md5:


### PR DESCRIPTION
Some implementations such as S3Proxy with the B2 backend do not return
ETag.