### PR TITLE
add "limit" option to "ls" and "la" commands to return the specified number of objects instead of returning all objects.

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -76,6 +76,7 @@ class Config(object):
     delete_after = False
     delete_after_fetch = False
     max_delete = -1
+    limit = -1
     _doc['delete_removed'] = "[sync] Remove remote S3 objects when local file has been deleted"
     delay_updates = False  # OBSOLETE
     gpg_passphrase = ""

--- a/s3cmd
+++ b/s3cmd
@@ -117,7 +117,7 @@ def cmd_ls(args):
     if len(args) > 0:
         uri = S3Uri(args[0])
         if uri.type == "s3" and uri.has_bucket():
-            subcmd_bucket_list(s3, uri)
+            subcmd_bucket_list(s3, uri, cfg.limit)
             return EX_OK
 
     # If not a s3 type uri or no bucket was provided, list all the buckets
@@ -138,11 +138,11 @@ def cmd_all_buckets_list_all_content(args):
     response = s3.list_all_buckets()
 
     for bucket in response["list"]:
-        subcmd_bucket_list(s3, S3Uri("s3://" + bucket["Name"]))
+        subcmd_bucket_list(s3, S3Uri("s3://" + bucket["Name"]), cfg.limit)
         output(u"")
     return EX_OK
 
-def subcmd_bucket_list(s3, uri):
+def subcmd_bucket_list(s3, uri, limit):
     bucket = uri.bucket()
     prefix = uri.object()
 
@@ -150,7 +150,7 @@ def subcmd_bucket_list(s3, uri):
     if prefix.endswith('*'):
         prefix = prefix[:-1]
     try:
-        response = s3.bucket_list(bucket, prefix = prefix)
+        response = s3.bucket_list(bucket, prefix = prefix, limit = limit)
     except S3Error, e:
         if S3.codes.has_key(e.info["Code"]):
             error(S3.codes[e.info["Code"]] % bucket)
@@ -194,6 +194,9 @@ def subcmd_bucket_list(s3, uri):
             "storageclass" : storageclass,
             "uri": uri.compose_uri(bucket, object["Key"]),
             })
+
+    if response["truncated"]:
+        warning(u"The list is truncated because the settings limit was reached.")
 
 def cmd_bucket_create(args):
     s3 = S3(Config())
@@ -2531,6 +2534,7 @@ def main():
     optparser.add_option(      "--delete-after", dest="delete_after", action="store_true", help="Perform deletes after new uploads [sync]")
     optparser.add_option(      "--delay-updates", dest="delay_updates", action="store_true", help="*OBSOLETE* Put all updated files into place at end [sync]")  # OBSOLETE
     optparser.add_option(      "--max-delete", dest="max_delete", action="store", help="Do not delete more than NUM files. [del] and [sync]", metavar="NUM")
+    optparser.add_option(      "--limit", dest="limit", action="store", help="Limit number of objects returned in the response body (only for [ls] and [la] commands)", metavar="NUM")
     optparser.add_option(      "--add-destination", dest="additional_destinations", action="append", help="Additional destination for parallel uploads, in addition to last arg.  May be repeated.")
     optparser.add_option(      "--delete-after-fetch", dest="delete_after_fetch", action="store_true", help="Delete remote objects after fetching to local file (only for [get] and [sync] commands).")
     optparser.add_option("-p", "--preserve", dest="preserve_attrs", action="store_true", help="Preserve filesystem attributes (mode, ownership, timestamps). Default for [sync] command.")


### PR DESCRIPTION
Currently "ls" command returns all objects within a bucket under a certain prefix using the delimiter '/' and there seems to be no option to limit the number of returned objects. If the contents of the main folder or a sub-folder is huge, it will continue to list all objects until it finishes. Its possible to take time to finish it and it could be overloaded the S3 server side.

This change is to add "max-ls-keys" option to "ls" command to return the specified number of objects instead of returning all objects.

