### PR TITLE
Extract hostname if hostname is configured as "host:port"

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -6,6 +6,7 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+import re
 import sys
 import httplib
 import ssl
@@ -110,7 +111,10 @@ class http_connection(object):
     def match_hostname(self):
         cert = self.c.sock.getpeercert()
         try:
-            ssl.match_hostname(cert, self.hostname)
+            if re.match('[^\:]+:[0-9]+', self.hostname):
+                ssl.match_hostname(cert, self.hostname.split(':')[0])
+            else:
+                ssl.match_hostname(cert, self.hostname)
         except AttributeError: # old ssl module doesn't have this function
             return
         except ValueError: # empty SSL cert means underlying SSL library didn't validate it, we don't either.


### PR DESCRIPTION
If hostname was set as "host:port" in for example `--host`, both the
host and port would be used in `ssl.check_hostname()` which expects
only a hostname.

For example, "foo.com:8443" would be checked against the certificate
of "foo.com", and fail.

Fixes #741