### PR TITLE
Change proxy SSL URI to relative

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -280,7 +280,7 @@ class S3(object):
             uri = "/%s%s" % (resource['bucket'], resource['uri'])
         else:
             uri = resource['uri']
-        if self.config.proxy_host != "":
+        if self.config.proxy_host != "" and not self.config.use_https:
             uri = "http://%s%s" % (self.get_hostname(resource['bucket']), uri)
         debug('format_uri(): ' + uri)
         return uri


### PR DESCRIPTION
Proxy SSL/HTTPS requests use regular relative URIs, while only HTTP requests use absolute URIs