### PR TITLE
Support for custom S3 api path

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -161,6 +161,11 @@ class http_connection(object):
         parsed_hostname = urlparse('https://' + hostname)
         self.hostname = parsed_hostname.hostname
         self.port = parsed_hostname.port
+        if parsed_hostname.path and parsed_hostname.path != '/':
+            self.path = parsed_hostname.path.rstrip('/')
+            debug(u'endpoint path set to %s', self.path)
+        else:
+            self.path = None
 
         """
         History note:


### PR DESCRIPTION
This changes allows user to set path to S3 api instead of default '/'. It will enable s3cmd to work with s3ninja or custom s3-ceph endpoints. 