### PR TITLE
fix: handle empty md5 in find_md5_one

### DIFF
--- a/S3/FileDict.py
+++ b/S3/FileDict.py
@@ -28,7 +28,7 @@ class FileDict(SortedDict):
         self.by_md5[md5].add(relative_file)
 
     def find_md5_one(self, md5):
-        if md5 is None: return None
+        if not md5: return None
         try:
             return list(self.by_md5.get(md5, set()))[0]
         except:


### PR DESCRIPTION
`s3cmd sync` was found to be misbehaving with ceph v0.94.2. It was due to a bug in radosgw that returned empty ETags. http://tracker.ceph.com/issues/12955. This PR handles such cases with empty ETags.