### PR TITLE
Make 'acl_public' settings to honor false values

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -319,7 +319,7 @@ class Config(object):
                 return
 
         ## allow yes/no, true/false, on/off and 1/0 for boolean options
-        elif type(getattr(Config, option)) is type(True):   # bool
+        elif type(getattr(Config, option)) is type(True) or option == 'acl_public':   # bool
             if str(value).lower() in ("true", "yes", "on", "1"):
                 value = True
             elif str(value).lower() in ("false", "no", "off", "0"):


### PR DESCRIPTION
Explicitly treat the 'acl_public' option in configuration file as a
boolean.

As the 'acl_public' option defaults to None, it wasn't treated as a boolean
value and the conversion from string in configuration to boolean did not
happen. Therefore the value from the configuration (eg. 'False') remained
as a string and evaluated to true in boolean context.
