### PR TITLE
Raise warning on filename encoding errors

### DIFF
--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -276,6 +276,8 @@ def fetch_local_list(args, is_src = False, recursive = None):
                 if not os.path.isfile(deunicodise(full_name)):
                     if os.path.exists(deunicodise(full_name)):
                         warning(u"Skipping over non regular file: %s" % full_name)
+                    elif u'\ufffd' in full_name:
+                        warning(u"Skipping file with encoding problem: %s" % full_name)
                     continue
                 if os.path.islink(deunicodise(full_name)):
                     if not cfg.follow_symlinks:


### PR DESCRIPTION
I have a few files with filenames containing non-UTF8 characters, and `s3cmd sync` skips these files. This is what I see with `--debug`:

    INFO: Compiling list of local files...
    DEBUG: Unicodising '03 Radiohead - How Do You\xbf.mp3' using UTF-8
    DEBUG: DeUnicodising u'(1993) Pablo Honey/03 Radiohead - How Do You\ufffd.mp3' using UTF-8

In [S3/FileLists.py:275](https://github.com/s3tools/s3cmd/blob/master/S3/FileLists.py#L275), this file is skipped, because no file with that name can be found on disk. I believe it's useful for s3cmd to not skip the file silently, but to raise a warning, so that the user is aware of the problem and can fix it.

~~If desired, the warning could be raised only if the unicode string contains U+FFFD, the unicode replacement character.~~
