### PR TITLE
Python3: make relative imports explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ before_script:
     - sleep 4 # give minio some time to start
 # command to run tests
 ## Tests stopped at test 23 because minio doesn't support "quote_plus" used in signatures.
-script: ./run-tests-minio.py -c .travis.s3cfg -p baseauto 1..23
+script: python ./run-tests-minio.py -c .travis.s3cfg -p baseauto 1..23
 after_script:
     - killall minio

--- a/S3/ACL.py
+++ b/S3/ACL.py
@@ -6,9 +6,9 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from Utils import getTreeFromXml, deunicodise
+from .Utils import getTreeFromXml, deunicodise
 
 try:
     import xml.etree.ElementTree as ET

--- a/S3/AccessLog.py
+++ b/S3/AccessLog.py
@@ -6,12 +6,12 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-import S3Uri
-from Exceptions import ParameterError
-from Utils import getTreeFromXml
-from ACL import GranteeAnonRead
+from . import S3Uri
+from .Exceptions import ParameterError
+from .Utils import getTreeFromXml
+from .ACL import GranteeAnonRead
 
 try:
     import xml.etree.ElementTree as ET

--- a/S3/CloudFront.py
+++ b/S3/CloudFront.py
@@ -6,6 +6,8 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+from __future__ import absolute_import
+
 import sys
 import time
 import random
@@ -17,13 +19,13 @@ try:
 except ImportError:
     import elementtree.ElementTree as ET
 
-from S3 import S3
-from Config import Config
-from Exceptions import *
-from Utils import getTreeFromXml, appendXmlTextNode, getDictFromTree, dateS3toPython, getBucketFromHostname, getHostnameFromBucket, deunicodise
-from Crypto import sign_string_v2
-from S3Uri import S3Uri, S3UriS3
-from ConnMan import ConnMan
+from .S3 import S3
+from .Config import Config
+from .Exceptions import *
+from .Utils import getTreeFromXml, appendXmlTextNode, getDictFromTree, dateS3toPython, getBucketFromHostname, getHostnameFromBucket, deunicodise
+from .Crypto import sign_string_v2
+from .S3Uri import S3Uri, S3UriS3
+from .ConnMan import ConnMan
 
 cloudfront_api_version = "2010-11-01"
 cloudfront_resource = "/%(api_ver)s/distribution" % { 'api_ver' : cloudfront_api_version }

--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -6,16 +6,18 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+from __future__ import absolute_import
+
 import sys
-from custom_httplib27 import httplib
+from .custom_httplib27 import httplib
 import ssl
 from threading import Semaphore
 from logging import debug
 from urlparse import urlparse
 
-from Config import Config
-from Exceptions import ParameterError
-from Utils import getBucketFromHostname
+from .Config import Config
+from .Exceptions import ParameterError
+from .Utils import getBucketFromHostname
 
 if not 'CertificateError ' in ssl.__dict__:
     class CertificateError(Exception):

--- a/S3/Crypto.py
+++ b/S3/Crypto.py
@@ -6,13 +6,15 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+from __future__ import absolute_import
+
 import sys
 import hmac
 import base64
 
-import Config
+from . import Config
 from logging import debug
-from Utils import encode_to_s3, time_to_epoch, deunicodise
+from .Utils import encode_to_s3, time_to_epoch, deunicodise
 
 import datetime
 import urllib
@@ -20,7 +22,7 @@ import urllib
 # hashlib backported to python 2.4 / 2.5 is not compatible with hmac!
 if sys.version_info[0] == 2 and sys.version_info[1] < 6:
     import sha as sha1
-    from Crypto.Hash import SHA256 as sha256
+    from .Crypto.Hash import SHA256 as sha256
 else:
     from hashlib import sha1, sha256
 

--- a/S3/Exceptions.py
+++ b/S3/Exceptions.py
@@ -6,9 +6,11 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
-from Utils import getTreeFromXml, unicodise, deunicodise
+from __future__ import absolute_import
+
+from .Utils import getTreeFromXml, unicodise, deunicodise
 from logging import debug, error
-import ExitCodes
+from . import ExitCodes
 
 try:
     from xml.etree.ElementTree import ParseError as XmlParseError

--- a/S3/FileDict.py
+++ b/S3/FileDict.py
@@ -6,10 +6,12 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+from __future__ import absolute_import
+
 import logging
-from SortedDict import SortedDict
-import Utils
-import Config
+from .SortedDict import SortedDict
+from . import Utils
+from . import Config
 
 zero_length_md5 = "d41d8cd98f00b204e9800998ecf8427e"
 cfg = Config.Config()

--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -6,13 +6,15 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
-from S3 import S3
-from Config import Config
-from S3Uri import S3Uri
-from FileDict import FileDict
-from Utils import *
-from Exceptions import ParameterError
-from HashCache import HashCache
+from __future__ import absolute_import
+
+from .S3 import S3
+from .Config import Config
+from .S3Uri import S3Uri
+from .FileDict import FileDict
+from .Utils import *
+from .Exceptions import ParameterError
+from .HashCache import HashCache
 
 from logging import debug, info, warning
 

--- a/S3/HashCache.py
+++ b/S3/HashCache.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import cPickle as pickle
-from Utils import deunicodise
+from .Utils import deunicodise
 
 class HashCache(object):
     def __init__(self):

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -4,11 +4,13 @@
 ## Author: Jerome Leclanche <jerome.leclanche@gmail.com>
 ## License: GPL Version 2
 
+from __future__ import absolute_import
+
 import os
 import sys
 from stat import ST_SIZE
 from logging import debug, info, warning, error
-from Utils import getTextFromXml, getTreeFromXml, formatSize, unicodise, deunicodise, calculateChecksum, parseNodes, encode_to_s3
+from .Utils import getTextFromXml, getTreeFromXml, formatSize, unicodise, deunicodise, calculateChecksum, parseNodes, encode_to_s3
 
 class MultiPartUpload(object):
 

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -6,6 +6,8 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+from __future__ import absolute_import
+
 import sys
 import os
 import time
@@ -24,17 +26,17 @@ try:
 except ImportError:
     from md5 import md5
 
-from Utils import *
-from SortedDict import SortedDict
-from AccessLog import AccessLog
-from ACL import ACL, GranteeLogDelivery
-from BidirMap import BidirMap
-from Config import Config
-from Exceptions import *
-from MultiPart import MultiPartUpload
-from S3Uri import S3Uri
-from ConnMan import ConnMan, CertificateError
-from Crypto import sign_string_v2, sign_string_v4, checksum_sha256_file, checksum_sha256_buffer
+from .Utils import *
+from .SortedDict import SortedDict
+from .AccessLog import AccessLog
+from .ACL import ACL, GranteeLogDelivery
+from .BidirMap import BidirMap
+from .Config import Config
+from .Exceptions import *
+from .MultiPart import MultiPartUpload
+from .S3Uri import S3Uri
+from .ConnMan import ConnMan, CertificateError
+from .Crypto import sign_string_v2, sign_string_v4, checksum_sha256_file, checksum_sha256_buffer
 
 try:
     from ctypes import ArgumentError

--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -6,13 +6,13 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
 import os
 import re
 import sys
-from Utils import unicodise, deunicodise, check_bucket_name_dns_support
-import Config
+from .Utils import unicodise, deunicodise, check_bucket_name_dns_support
+from . import Config
 
 class S3Uri(object):
     type = None

--- a/S3/SortedDict.py
+++ b/S3/SortedDict.py
@@ -6,9 +6,9 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
-from __future__ import print_function
+from __future__ import absolute_import, print_function
 
-from BidirMap import BidirMap
+from .BidirMap import BidirMap
 
 class SortedDictIterator(object):
     def __init__(self, sorted_dict, keys):

--- a/run-tests-minio.py
+++ b/run-tests-minio.py
@@ -7,6 +7,8 @@
 ## License: GPL Version 2
 ## Copyright: TGRMN Software and contributors
 
+from __future__ import print_function
+
 import sys
 import os
 import re
@@ -62,17 +64,17 @@ elif os.name == "nt" and os.getenv("USERPROFILE"):
 if not os.path.isdir('testsuite') and os.path.isfile('testsuite.tar.gz'):
     os.system("tar -xz -f testsuite.tar.gz")
 if not os.path.isdir('testsuite'):
-    print "Something went wrong while unpacking testsuite.tar.gz"
+    print("Something went wrong while unpacking testsuite.tar.gz")
     sys.exit(1)
 
 os.system("tar -xf testsuite/checksum.tar -C testsuite")
 if not os.path.isfile('testsuite/checksum/cksum33.txt'):
-    print "Something went wrong while unpacking testsuite/checkum.tar"
+    print("Something went wrong while unpacking testsuite/checkum.tar")
     sys.exit(1)
 
 ## Fix up permissions for permission-denied tests
-os.chmod("testsuite/permission-tests/permission-denied-dir", 0444)
-os.chmod("testsuite/permission-tests/permission-denied.txt", 0000)
+os.chmod("testsuite/permission-tests/permission-denied-dir", 0o444)
+os.chmod("testsuite/permission-tests/permission-denied.txt", 0o000)
 
 ## Patterns for Unicode tests
 patterns = {}
@@ -81,10 +83,10 @@ patterns['GBK'] = u"12月31日/1-特色條目"
 
 encoding = locale.getpreferredencoding()
 if not encoding:
-    print "Guessing current system encoding failed. Consider setting $LANG variable."
+    print("Guessing current system encoding failed. Consider setting $LANG variable.")
     sys.exit(1)
 else:
-    print "System encoding: " + encoding
+    print("System encoding: " + encoding)
 
 have_encoding = os.path.isdir('testsuite/encodings/' + encoding)
 if not have_encoding and os.path.isfile('testsuite/encodings/%s.tar.gz' % encoding):
@@ -95,7 +97,7 @@ if have_encoding:
     #enc_base_remote = "%s/xyz/%s/" % (pbucket(1), encoding)
     enc_pattern = patterns[encoding]
 else:
-    print encoding + " specific files not found."
+    print(encoding + " specific files not found.")
 # Minio: disable encoding tests
 have_encoding = False
 
@@ -106,17 +108,17 @@ if not os.path.isdir('testsuite/crappy-file-name'):
 
 def test(label, cmd_args = [], retcode = 0, must_find = [], must_not_find = [], must_find_re = [], must_not_find_re = [], stdin = None):
     def command_output():
-        print "----"
-        print " ".join([" " in arg and "'%s'" % arg or arg for arg in cmd_args])
-        print "----"
-        print stdout
-        print "----"
+        print("----")
+        print(" ".join([" " in arg and "'%s'" % arg or arg for arg in cmd_args]))
+        print("----")
+        print(stdout)
+        print("----")
 
     def failure(message = ""):
         global count_fail
         if message:
             message = u"  (%r)" % message
-        print u"\x1b[31;1mFAIL%s\x1b[0m" % (message)
+        print(u"\x1b[31;1mFAIL%s\x1b[0m" % (message))
         count_fail += 1
         command_output()
         #return 1
@@ -125,7 +127,7 @@ def test(label, cmd_args = [], retcode = 0, must_find = [], must_not_find = [], 
         global count_pass
         if message:
             message = "  (%r)" % message
-        print "\x1b[32;1mOK\x1b[0m%s" % (message)
+        print("\x1b[32;1mOK\x1b[0m%s" % (message))
         count_pass += 1
         if verbose:
             command_output()
@@ -134,7 +136,7 @@ def test(label, cmd_args = [], retcode = 0, must_find = [], must_not_find = [], 
         global count_skip
         if message:
             message = "  (%r)" % message
-        print "\x1b[33;1mSKIP\x1b[0m%s" % (message)
+        print("\x1b[33;1mSKIP\x1b[0m%s" % (message))
         count_skip += 1
         return 0
     def compile_list(_list, regexps = False):
@@ -145,7 +147,7 @@ def test(label, cmd_args = [], retcode = 0, must_find = [], must_not_find = [], 
 
     global test_counter
     test_counter += 1
-    print ("%3d  %s " % (test_counter, label)).ljust(30, "."),
+    print(("%3d  %s " % (test_counter, label)).ljust(30, "."), end=' ')
     sys.stdout.flush()
 
     if run_tests.count(test_counter) == 0 or exclude_tests.count(test_counter) > 0:
@@ -192,7 +194,7 @@ def test(label, cmd_args = [], retcode = 0, must_find = [], must_not_find = [], 
 
 def test_s3cmd(label, cmd_args = [], **kwargs):
     if not cmd_args[0].endswith("s3cmd"):
-        cmd_args.insert(0, "python2")
+        cmd_args.insert(0, "python")
         cmd_args.insert(1, "s3cmd")
         if config_file:
             cmd_args.insert(2, "-c")
@@ -204,7 +206,7 @@ def test_mkdir(label, dir_name):
     if os.name in ("posix", "nt"):
         cmd = ['mkdir', '-p']
     else:
-        print "Unknown platform: %s" % os.name
+        print("Unknown platform: %s" % os.name)
         sys.exit(1)
     cmd.append(dir_name)
     return test(label, cmd)
@@ -216,7 +218,7 @@ def test_rmdir(label, dir_name):
         elif os.name == "nt":
             cmd = ['rmdir', '/s/q']
         else:
-            print "Unknown platform: %s" % os.name
+            print("Unknown platform: %s" % os.name)
             sys.exit(1)
         cmd.append(dir_name)
         return test(label, cmd)
@@ -233,7 +235,7 @@ def test_copy(label, src_file, dst_file):
     elif os.name == "nt":
         cmd = ['copy']
     else:
-        print "Unknown platform: %s" % os.name
+        print("Unknown platform: %s" % os.name)
         sys.exit(1)
     cmd.append(src_file)
     cmd.append(dst_file)
@@ -250,11 +252,11 @@ argv = sys.argv[1:]
 while argv:
     arg = argv.pop(0)
     if arg.startswith('--bucket-prefix='):
-        print "Usage: '--bucket-prefix PREFIX', not '--bucket-prefix=PREFIX'"
+        print("Usage: '--bucket-prefix PREFIX', not '--bucket-prefix=PREFIX'")
         sys.exit(0)
     if arg in ("-h", "--help"):
-        print "%s A B K..O -N" % sys.argv[0]
-        print "Run tests number A, B and K through to O, except for N"
+        print("%s A B K..O -N" % sys.argv[0])
+        print("Run tests number A, B and K through to O, except for N")
         sys.exit(0)
 
     if arg in ("-c", "--config"):
@@ -270,7 +272,7 @@ while argv:
         try:
             bucket_prefix = argv.pop(0)
         except IndexError:
-            print "Bucket prefix option must explicitly supply a bucket name prefix"
+            print("Bucket prefix option must explicitly supply a bucket name prefix")
             sys.exit(0)
         continue
     if ".." in arg:
@@ -283,7 +285,7 @@ while argv:
     else:
         run_tests.append(int(arg))
 
-print "Using bucket prefix: '%s'" % bucket_prefix
+print("Using bucket prefix: '%s'" % bucket_prefix)
 
 cfg = S3.Config.Config(config_file)
 


### PR DESCRIPTION
Continue the effort for making it Python 3 compatible.
Some modules (Config, Utils, Progress) have cyclic dependency which makes it difficult to remove their implicit imports.
To keep this PR minimal, I do not attempt to resolve the above issue this time.