### PR TITLE
Improves gpg-encrypted get requests streamed to stdout

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -574,7 +574,7 @@ def cmd_object_get(args):
                 os.unlink(deunicodise(destination))
             raise
 
-        if response["headers"].has_key("x-amz-meta-s3tools-gpgenc"):
+        if response["headers"].has_key("x-amz-meta-s3tools-gpgenc") and destination != '-':
             gpg_decrypt(destination, response["headers"]["x-amz-meta-s3tools-gpgenc"])
             response["size"] = os.stat(deunicodise(destination))[6]
         if response["headers"].has_key("last-modified") and destination != "-":


### PR DESCRIPTION
This trivial change improves the behaviour of
gpg-encrypted get requests streamed to stdout.

Previous (broken) behaviour:
- Streams encrypted file contents to stdout
- Streams incorrect error message to stderr
- Creates empty file with pseudo-random name

Current (less broken) behaviour:
- Streams encrypted file contents to stdout

Correct behaviour:
- Streams decrypted file contents to stdout

Implementing the correct behaviour would require
significant architectural changes to how s3cmd
decrypts gpg-encrypted contents.

Current workaround to stream a gpg-encrypted
get request to stdout:
s3cmd --no-progress get s3://<bucket>/<file> - | gpg -d --quiet --no-use-agent --passphrase <passphrase>