### PR TITLE
Use http.client for Python 3

### DIFF
--- a/S3/ConnMan.py
+++ b/S3/ConnMan.py
@@ -9,7 +9,11 @@
 from __future__ import absolute_import
 
 import sys
-from .custom_httplib27 import httplib
+try:
+    # python 3 support
+    import http.client as httplib
+except ImportError:
+    from .custom_httplib27 import httplib
 import ssl
 from threading import Semaphore
 from logging import debug


### PR DESCRIPTION
The custom httplib isn't needed for Python 3 as it supports Continue.

https://github.com/python/cpython/blob/f15fa87e5a66c0000f63be5065ddee4a52d5660f/Lib/http/client.py#L294

This is untested as there's a lot more Python 3 changes to make, but I'm hoping to make some progress on that.