### PR TITLE
Fixes #849 by adding requester pays header to HEAD requests

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -142,7 +142,7 @@ class S3Request(object):
         self.requester_pays()
 
     def requester_pays(self):
-        if self.s3.config.requester_pays and self.method_string in ("GET", "POST", "PUT"):
+        if self.s3.config.requester_pays and self.method_string in ("GET", "POST", "PUT", "HEAD"):
             self.headers['x-amz-request-payer'] = 'requester'
 
     def update_timestamp(self):


### PR DESCRIPTION
See: https://github.com/s3tools/s3cmd/issues/849

“After you configure a bucket to be a Requester Pays bucket, requesters must include x-amz-request-payer in their requests either in the header, for POST, GET and **HEAD** requests, or as a parameter in a REST request to show that they understand that they will be charged for the request and the data download.”

http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html