### PR TITLE
run-tests.py: use lowercase bucket name

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -244,7 +244,7 @@ def test_curl_HEAD(label, src_file, **kwargs):
     cmd.append(src_file)
     return test(label, cmd, **kwargs)
 
-bucket_prefix = u"%s-" % getpass.getuser()
+bucket_prefix = u"%s-" % getpass.getuser().lower()
 
 argv = sys.argv[1:]
 while argv:


### PR DESCRIPTION
S3 does not support uppercase letters in bucket names. The bucket name
used for testing includes the user name, so convert it to lower case first.