### PR TITLE
Don't need to compute ETag md5sum match if it is not a real md5sum

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1540,7 +1540,7 @@ class S3(object):
         debug("MD5 sums: computed=%s, received=%s" % (md5_computed, response["headers"].get('etag', '').strip('"\'')))
         ## when using KMS encryption, MD5 etag value will not match
         md5_from_s3 = response["headers"].get("etag", "").strip('"\'')
-        if (md5_from_s3 != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
+        if ('-' not in md5_from_s3) and (md5_from_s3 != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
             warning("MD5 Sums don't match!")
             if retries:
                 warning("Retrying upload of %s" % (filename))


### PR DESCRIPTION
Fixes https://github.com/s3tools/s3cmd/issues/880