### PR TITLE
Add config to avoid checking MD5 on get and put

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -206,6 +206,7 @@ class Config(object):
     # s3 will timeout if a request/transfer is stuck for more than a short time
     throttle_max = 100
     public_url_use_https = False
+    put_check_etag = True
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None, access_token=None):

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1583,7 +1583,7 @@ class S3(object):
         debug("MD5 sums: computed=%s, received=%s" % (md5_computed, response["headers"].get('etag', '').strip('"\'')))
         ## when using KMS encryption, MD5 etag value will not match
         md5_from_s3 = response["headers"].get("etag", "").strip('"\'')
-        if ('-' not in md5_from_s3) and (md5_from_s3 != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
+        if self.config.put_check_etag and ('-' not in md5_from_s3) and (md5_from_s3 != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
             warning("MD5 Sums don't match!")
             if retries:
                 warning("Retrying upload of %s" % (filename))
@@ -1821,7 +1821,7 @@ class S3(object):
                 start_position + int(response["headers"]["content-length"]), response["size"]))
         debug("ReceiveFile: Computed MD5 = %s" % response.get("md5"))
         # avoid ETags from multipart uploads that aren't the real md5
-        if ('-' not in md5_from_s3 and not response["md5match"]) and (response["headers"].get("x-amz-server-side-encryption") != 'aws:kms'):
+        if self.config.put_check_etag and ('-' not in md5_from_s3 and not response["md5match"]) and (response["headers"].get("x-amz-server-side-encryption") != 'aws:kms'):
             warning("MD5 signatures do not match: computed=%s, received=%s" % (
                 response.get("md5"), md5_from_s3))
         return response

--- a/s3cmd
+++ b/s3cmd
@@ -2856,12 +2856,14 @@ def main():
 
     ## Process --(no-)check-md5
     if options.check_md5 == False:
+        cfg.put_check_etag = False
         try:
             cfg.sync_checks.remove("md5")
             cfg.preserve_attrs_list.remove("md5")
         except Exception:
             pass
     if options.check_md5 == True:
+        cfg.put_check_etag = True
         if cfg.sync_checks.count("md5") == 0:
             cfg.sync_checks.append("md5")
         if cfg.preserve_attrs_list.count("md5") == 0:


### PR DESCRIPTION
Overload existing `--no-check-md5`.  Object stores like S3Proxy cannot
return an MD5 ETag using some providers:

* Atmos returns nothing
* Azure returns an opaque ETag
* B2 returns a SHA1