### PR TITLE
Fix Python 3 bytes string encoding when getting IAM credentials

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -217,7 +217,7 @@ class Config(object):
             resp = conn.getresponse()
             files = resp.read()
             if resp.status == 200 and len(files)>1:
-                conn.request('GET', "/latest/meta-data/iam/security-credentials/%s"%files)
+                conn.request('GET', "/latest/meta-data/iam/security-credentials/%s"%files.decode())
                 resp=conn.getresponse()
                 if resp.status == 200:
                     creds=json.load(resp)


### PR DESCRIPTION
The `files` variable has a type of `bytes()` in Python 3.

For example, if `files = b'master'` then the request path would be formatted as
`"/latest/meta-data/iam/security-credentials/b'master'"`

The `.decode()` method converts a bytes into a proper string in Python 3 and doesn't change anything in Python 2.