### PR TITLE
Fixes #936 - Fix setacl command exception

### DIFF
--- a/S3/ACL.py
+++ b/S3/ACL.py
@@ -26,7 +26,7 @@ class Grantee(object):
         self.xsi_type = None
         self.tag = None
         self.name = None
-        self.display_name = None
+        self.display_name = ''
         self.permission = None
 
     def __repr__(self):
@@ -188,8 +188,8 @@ class ACL(object):
         if "ALL" == permission:
             self.grantees = [g for g in self.grantees if not (g.name.lower() == name or g.display_name.lower() == name)]
         else:
-            self.grantees = [g for g in self.grantees if not ((g.display_name.lower() == name and g.permission.upper() == permission)\
-                or (g.name.lower() == name and g.permission.upper() ==  permission))]
+            self.grantees = [g for g in self.grantees if not ((g.display_name.lower() == name or g.name.lower() == name)
+                and g.permission.upper() == permission)]
 
     def get_printable_tree(self):
         tree = getTreeFromXml(ACL.EMPTY_ACL)


### PR DESCRIPTION
Grantee.display_name may not be initialize for some Grantee types,
most notably for xsi:type="Group".
However, tolower() is called on this attribute in ACL.revoke(),
raising unhandled AttributeError. To prevent it, let's change
default value of Grantee.display_name to empty string with almost
identical semantical value, but allowing lower() call to succeed.

I also applied the Boolean Distributive law to simplify condition
in ACL.revoke().