### PR TITLE
Allow setting full_control on objects with public read access

### DIFF
--- a/S3/ACL.py
+++ b/S3/ACL.py
@@ -186,9 +186,9 @@ class ACL(object):
         permission = permission.upper()
 
         if "ALL" == permission:
-            self.grantees = [g for g in self.grantees if not (g.name.lower() == name or g.display_name.lower() == name)]
+            self.grantees = [g for g in self.grantees if not (g.name.lower() == name or (g.display_name is not None and g.display_name.lower() == name))]
         else:
-            self.grantees = [g for g in self.grantees if not ((g.display_name.lower() == name or g.name.lower() == name)
+            self.grantees = [g for g in self.grantees if not (((g.display_name is not None and g.display_name.lower() == name) or g.name.lower() == name)
                 and g.permission.upper() == permission)]
 
     def get_printable_tree(self):


### PR DESCRIPTION
display_name is None for the grantee corresponding to public access;
name is 'http://acs.amazonaws.com/groups/global/AllUsers'.

So if you try and grant full_control to a user on an object which is
public, the check at line 189 fails thus:

```python
    self.grantees = [g for g in self.grantees if not (g.name.lower() == name or g.display_name.lower() == name)]
AttributeError: 'NoneType' object has no attribute 'lower'
```

because g.display_name is None

This patch fixes this by checking for not-None before calling lower()

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>