### PR TITLE
Do not convert all regions to lower case

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -382,8 +382,6 @@ class S3(object):
             bucket_location = bucket_location.strip()
             if bucket_location.upper() == "EU":
                 bucket_location = bucket_location.upper()
-            else:
-                bucket_location = bucket_location.lower()
             body  = "<CreateBucketConfiguration><LocationConstraint>"
             body += bucket_location
             body += "</LocationConstraint></CreateBucketConfiguration>"


### PR DESCRIPTION
In-case of Minio which can support any arbitrary region names,
users might set the region with uppercase value which seems
to have been lowercased during make bucket. In-fact the
signature region scope is never lowercased - this creates
and inconsistent behavior.

Make bucket location constraint
```
DEBUG: bucket_location: <CreateBucketConfiguration><LocationConstraint>zzz</LocationConstraint></CreateBucketConfiguration>
```

Signature V4 headers
```
DEBUG: signature-v4 headers: {'x-amz-content-sha256': u'a70e963f9ce55e14adcaf0c3f9aae558bcd8b2d4bedd7f3f193a8b853640d5c2', 'Authorization': u'AWS4-HMAC-SHA256 Credential=minio/20180807/zzz/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=5a797cc1744abaa86a7a882c801ba0a35fb046dcddc93456871f9f5d49dec1e1', 'x-amz-date': '20180807T160640Z'}
```

This PR fixes this behavior by preserving region case in `.s3cfg`