### PR TITLE
Add extra headers to all requests, if they exist

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -16,6 +16,7 @@ import base64
 import mimetypes
 import io
 import pprint
+from copy import copy
 from xml.sax import saxutils
 from logging import debug, info, warning, error
 from stat import ST_SIZE
@@ -1123,7 +1124,13 @@ class S3(object):
 
         method_string = S3.http_methods.getkey(S3.operations[operation] & S3.http_methods["MASK"])
 
-        request = S3Request(self, method_string, resource, headers, body, uri_params)
+        _headers = copy(headers)
+        if not _headers and self.config.extra_headers is not None:
+            _headers = {}
+        if self.config.extra_headers is not None:
+            for k,v in self.config.extra_headers.iteritems():
+                _headers[k] = v
+        request = S3Request(self, method_string, resource, _headers, body, uri_params)
 
         debug("CreateRequest: resource[uri]=%s", resource['uri'])
         return request


### PR DESCRIPTION
At the moment, adding custom headers only works for simple put operations. With this change, one can use custom headers in any s3cmd operation.