### PR TITLE
Resolve binary vs unicode encodings in py3.7

### DIFF
--- a/S3/CloudFront.py
+++ b/S3/CloudFront.py
@@ -293,7 +293,7 @@ class InvalidationBatch(object):
                 path = "/" + path
             appendXmlTextNode("Path", urlencode_string(path), tree)
         appendXmlTextNode("CallerReference", self.reference, tree)
-        return ET.tostring(tree)
+        return ET.tostring(tree).decode('utf-8')
 
 class CloudFront(object):
     operations = {
@@ -603,7 +603,7 @@ class CloudFront(object):
                     continue
 
                 if CloudFront.dist_list.get(distListIndex, None) is None:
-                    CloudFront.dist_list[distListIndex] = set() 
+                    CloudFront.dist_list[distListIndex] = set()
 
                 CloudFront.dist_list[distListIndex].add(d.uri())
 

--- a/S3/Crypto.py
+++ b/S3/Crypto.py
@@ -65,8 +65,11 @@ def sign_string_v2(string_to_sign):
     string_to_sign should be utf-8 "bytes".
     """
     secret_key = Config.Config().secret_key
-    signature = base64.encodestring(hmac.new(encode_to_s3(secret_key), string_to_sign, sha1).digest()).strip()
-    return signature
+    encoded_secret = encode_to_s3(secret_key)
+    encoded_str = encode_to_s3(string_to_sign)
+    signature = base64.encodestring(hmac.new(encoded_secret, encoded_str, sha1).digest()).strip()
+    decoded_signature = decode_from_s3(signature)
+    return decoded_signature
 __all__.append("sign_string_v2")
 
 def sign_request_v2(method='GET', canonical_uri='/', params=None, cur_headers=None):


### PR DESCRIPTION
This patch addresses #1006.

Hard for me to say if the changes I've made will break other versions of python. This works for 3.7.