### PR TITLE
Fix http.client.RemoteDisconnected errors

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1660,8 +1660,6 @@ class S3(object):
             debug("Response:\n" + pprint.pformat(response))
         except ParameterError as e:
             raise
-        except OSError as e:
-            raise
         except (IOError, Exception) as e:
             if self.config.progress_meter:
                 progress.done("failed")


### PR DESCRIPTION
With this commit 4 years ago OSError was caught:

https://github.com/s3tools/s3cmd/commit/889c5a7ba1ef8fc48f0c1be593e7ddf1e518a408

Looks like there wasn't a good reason to include it give the comment. Also now with python 3 http.client.RemoteDisconnected is getting caught by OSError.

I see @fviard tried to make a fix for RemoteDisconnected here:

https://github.com/s3tools/s3cmd/commit/b4f1424a18a3231230e6c5676d88cd68aa24feba

but the problem persisted until I removed these lines.  There may be other places in the code that have the same issue but this fixed my specific issues with recv_file():

```Traceback (most recent call last):
  File "/usr/bin/s3cmd", line 1316, in _download
    response = s3.object_get(uri, dst_stream, dst_file, extra_label = seq_label)
            http_response = conn.c.getresponse()
  File "/usr/lib/python3/dist-packages/S3/S3.py", line 715, in object_get
    response = self.recv_file(request, stream, labels, start_position)
  File "/usr/lib/python3/dist-packages/S3/S3.py", line 1612, in recv_file
    http_response = conn.c.getresponse()
  File "/usr/lib/python3.6/http/client.py", line 1331, in getresponse
    response.begin()
  File "/usr/lib/python3/dist-packages/S3/Custom_httplib3x.py", line 53, in httpresponse_patched_begin
    version, status, reason = self._read_status()
  File "/usr/lib/python3.6/http/client.py", line 266, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response```

I deployed this fix and verified it fixed the errors across our servers.