### PR TITLE
Fix signurl to honor host_bucket config option

### DIFF
--- a/S3/Crypto.py
+++ b/S3/Crypto.py
@@ -141,7 +141,6 @@ def sign_url_base_v2(**parms):
     content_type=Config.Config().content_type
     parms['expiry']=time_to_epoch(parms['expiry'])
     parms['access_key']=Config.Config().access_key
-    parms['host_base']=Config.Config().host_base
     parms['object'] = s3_quote(parms['object'], quote_backslashes=False, unicode_output=True)
     parms['proto'] = 'http'
     if Config.Config().signurl_use_https:
@@ -158,7 +157,15 @@ def sign_url_base_v2(**parms):
     debug("Signing plaintext: %r", signtext)
     parms['sig'] = s3_quote(sign_string_v2(encode_to_s3(signtext)), unicode_output=True)
     debug("Urlencoded signature: %s", parms['sig'])
-    url = "%(proto)s://%(bucket)s.%(host_base)s/%(object)s?AWSAccessKeyId=%(access_key)s&Expires=%(expiry)d&Signature=%(sig)s" % parms
+    host_bucket = Config.Config().host_bucket
+    url_format = ''.join([ "%(proto)s://",
+                           host_bucket,
+                           "/",
+                           '%(bucket)s/' if '%(bucket)s' not in host_bucket else '',
+                           "%(object)s",
+                           "?",
+                           "AWSAccessKeyId=%(access_key)s&Expires=%(expiry)d&Signature=%(sig)s" ])
+    url = url_format % parms
     if content_disposition:
         url += "&response-content-disposition=" + s3_quote(content_disposition, unicode_output=True)
     if content_type:


### PR DESCRIPTION
The host_bucket option, introduced in 84168b2be592823d0a36f24ff334e55a35987be2,
had been ignored in the signurl command, which would create invalid
signature URLs for S3 API endpoints not using bucket hostnames
(such as, for example, Ceph radosgw).

Thus, fix Crypto.sign_url_base_v2() to honor the host_bucket option.

Also, detect whether we are using bucket hostnames at all (based on
whether %(bucket)s is included in host_bucket or not), and if we
are not, then inject the bucket name into the signed URL.

* * *

Travis breaks for me when I run this, albeit *not* in the `signurl` test cases. The Travis result I get is:

```
 51  sign string ............. OK
 52  signurl time ............ OK
 53  signurl time offset ..... OK
 54  signurl content disposition and type  OK
 55  Rename within S3 ........ OK
 56  Sync remote2remote ...... FAIL  ('retcode: 1, expected one of: [0]')
----
python s3cmd -c .travis.s3cfg sync s3://baseautos3cmd-autotest-1/xyz/ s3://baseautos3cmd-autotest-2/copy/ --delete-removed --exclude non-printables*
----
Summary: 25 source files to copy, 1 files at destination to delete
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/dir1/file1-1.txt' -> 's3://baseautos3cmd-autotest-2/copy/demo/dir1/file1-1.txt'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/dir1/file1-2.txt' -> 's3://baseautos3cmd-autotest-2/copy/demo/dir1/file1-2.txt'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/dir2/file2-2.txt' -> 's3://baseautos3cmd-autotest-2/copy/demo/dir2/file2-2.txt'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/etc2/Logo.PNG' -> 's3://baseautos3cmd-autotest-2/copy/etc2/Logo.PNG'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/binary/random-crap' -> 's3://baseautos3cmd-autotest-2/copy/binary/random-crap'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/binary/random-crap.md5' -> 's3://baseautos3cmd-autotest-2/copy/binary/random-crap.md5'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/blahBlah/Blah.txt' -> 's3://baseautos3cmd-autotest-2/copy/blahBlah/Blah.txt'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/blahBlah/blah.txt' -> 's3://baseautos3cmd-autotest-2/copy/blahBlah/blah.txt'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/checksum.tar' -> 's3://baseautos3cmd-autotest-2/copy/checksum.tar'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/checksum/cksum2.txt' -> 's3://baseautos3cmd-autotest-2/copy/checksum/cksum2.txt'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/crappy-file-name.tar.gz' -> 's3://baseautos3cmd-autotest-2/copy/crappy-file-name.tar.gz'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/dir1/file1-3.log' -> 's3://baseautos3cmd-autotest-2/copy/demo/dir1/file1-3.log'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/dir2/file2-1.bin' -> 's3://baseautos3cmd-autotest-2/copy/demo/dir2/file2-1.bin'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/dir2/file2-3.log' -> 's3://baseautos3cmd-autotest-2/copy/demo/dir2/file2-3.log'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/demo/some-file.xml' -> 's3://baseautos3cmd-autotest-2/copy/demo/some-file.xml'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/dir-test/file-dir' -> 's3://baseautos3cmd-autotest-2/copy/dir-test/file-dir'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/encodings/GBK.tar.gz' -> 's3://baseautos3cmd-autotest-2/copy/encodings/GBK.tar.gz'
remote copy: 's3://baseautos3cmd-autotest-1/xyz/encodings/UTF-8.tar.gz' -> 's3://baseautos3cmd-autotest-2/copy/encodings/UTF-8.tar.gz'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
  Please try reproducing the error using
  the latest s3cmd code from the git master
  branch found at:
    https://github.com/s3tools/s3cmd
  and have a look at the known issues list:
    https://github.com/s3tools/s3cmd/wiki/Common-known-issues-and-their-solutions
  If the error persists, please report the
  following lines (removing any private
  info as necessary) to:
   s3tools-bugs@lists.sourceforge.net
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

So it looks like the `remote2remote` test is failing, and I'm not quite sure what to do about that.