### PR TITLE
Return decoded response in get_policy and get_cors

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -966,7 +966,7 @@ class S3(object):
         request = self.create_request("BUCKET_LIST", bucket = uri.bucket(),
                                       uri_params = {'policy': None})
         response = self.send_request(request)
-        return response['data']
+        return decode_from_s3(response['data'])
 
     def set_policy(self, uri, policy):
         headers = SortedDict(ignore_case = True)
@@ -989,7 +989,7 @@ class S3(object):
         request = self.create_request("BUCKET_LIST", bucket = uri.bucket(),
                                       uri_params = {'cors': None})
         response = self.send_request(request)
-        return response['data']
+        return decode_from_s3(response['data'])
 
     def set_cors(self, uri, cors):
         headers = SortedDict(ignore_case = True)


### PR DESCRIPTION
This patch allows cmd_info to work properly in case of getting any unicode chars in reply to bucket Policy/CORS requests.
Fixes at least #847