### PR TITLE
Configurable public URL protocol

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -205,6 +205,7 @@ class Config(object):
     # Maximum sleep duration for throtte / limitrate.
     # s3 will timeout if a request/transfer is stuck for more than a short time
     throttle_max = 100
+    public_url_use_https = False
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None, access_token=None):

--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -91,7 +91,7 @@ class S3UriS3(S3Uri):
 
     def public_url(self):
         public_url_protocol = "http"
-        if Config.Config().use_https:
+        if Config.Config().public_url_use_https:
             public_url_protocol = "https"
         if self.is_dns_compatible():
             return "%s://%s.%s/%s" % (public_url_protocol, self._bucket, Config.Config().host_base, self._object)

--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -90,10 +90,13 @@ class S3UriS3(S3Uri):
         return check_bucket_name_dns_support(Config.Config().host_bucket, self._bucket)
 
     def public_url(self):
+        public_url_protocol = "http"
+        if Config.Config().use_https:
+            public_url_protocol = "https"
         if self.is_dns_compatible():
-            return "http://%s.%s/%s" % (self._bucket, Config.Config().host_base, self._object)
+            return "%s://%s.%s/%s" % (public_url_protocol, self._bucket, Config.Config().host_base, self._object)
         else:
-            return "http://%s/%s/%s" % (Config.Config().host_base, self._bucket, self._object)
+            return "%s://%s/%s/%s" % (public_url_protocol, Config.Config().host_base, self._bucket, self._object)
 
     def host_name(self):
         if self.is_dns_compatible():


### PR DESCRIPTION
If public_url_use_https is true, prefix public URLs with https. Otherwise use
http as before.