### PR TITLE
Fix simple typo: unecessarily -> unnecessarily

### DIFF
--- a/S3/Custom_httplib27.py
+++ b/S3/Custom_httplib27.py
@@ -147,7 +147,7 @@ def httpconnection_patched_send_request(self, method, url, body, headers):
         self.putheader(encode_to_s3(hdr), encode_to_s3(value))
 
     # If an Expect: 100-continue was sent, we need to check for a 417
-    # Expectation Failed to avoid unecessarily sending the body
+    # Expectation Failed to avoid unnecessarily sending the body
     # See RFC 2616 8.2.3
     if not expect_continue:
         self.endheaders(body)

--- a/S3/Custom_httplib3x.py
+++ b/S3/Custom_httplib3x.py
@@ -193,7 +193,7 @@ def httpconnection_patched_send_request(self, method, url, body, headers,
         body = _encode(body, 'body')
 
     # If an Expect: 100-continue was sent, we need to check for a 417
-    # Expectation Failed to avoid unecessarily sending the body
+    # Expectation Failed to avoid unnecessarily sending the body
     # See RFC 2616 8.2.3
     if not expect_continue:
         self.endheaders(body, encode_chunked=encode_chunked)


### PR DESCRIPTION
Closes #1062

