### PR TITLE
Changed "Buckets list" test to use pbucket rather than hardcoded names.

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -375,7 +375,7 @@ test_s3cmd("Invalid bucket name", ["mb", "--bucket-location=EU", pbucket('EU')],
 
 ## ====== Buckets list
 test_s3cmd("Buckets list", ["ls"],
-    must_find = [ "autotest-1", "autotest-2", "Autotest-3" ], must_not_find_re = "autotest-EU")
+    must_find = [ pbucket(1), pbucket(2), pbucket(3) ], must_not_find_re = pbucket('EU'))
 
 
 ## ====== Sync to S3


### PR DESCRIPTION
This fixes issue #1066.

Tested on Python 2.7.17, 3.8.1, and 3.7.6 via run-tests.py - All tests pass.

While it would be possible to fix this simply by changing the "Autotest-3" to "autotest-3", using pbucket() should help reduce the chances of something like this happening in the future.