### PR TITLE
Feature: Allow use of Docker to run test cases with multiple Python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/*
 s3cmd.egg-info
 s3cmd.spec
 .idea
+.s3cfg

--- a/run-tests.docker.README.md
+++ b/run-tests.docker.README.md
@@ -1,0 +1,45 @@
+# Running test cases with Docker
+## (The  markdown formatting in this file is best viewed on Github)
+
+### tl;dr
+
+* `docker build -t s3cmd-tests --build-arg pyVersion=3.6 -f run-tests.dockerfile .` - Note the trailing period and substitute your desired Python version as needed.
+* `docker run --rm s3cmd-tests`
+
+### More Details
+
+The included run-tests.dockerfile allows contributors to easily test their changes with Python versions that aren't installed locally.
+
+Docker must, of course, be installed on your system if it is not already. See https://docs.docker.com/install/ for instructions.
+
+To begin, build the Dockerfile into an image for the Python version you wish to test against.  The build must be repeated whenever your source changes, but the Python image itself will be cached.  To build:
+
+* Place a valid .s3cfg file in the root project directory.  While .s3cfg has been added to the .gitignore to avoid sending your credentials to public repositories, you should still make sure you remove it when your testing is complete.
+
+* Run `docker build -t s3cmd-tests -f run-tests.dockerfile .` (the trailing period is required)
+
+  This will:
+
+  * Download the latest Python Docker image
+  * Add a testuser group and account
+  * Copy the .s3cfg into the user's home directory (/home/testuser)
+  * Copy the entire project folder into /home/testuser/src/s3cmd
+  * Install s3cmd dependencies (as root)
+
+The main purpose of this Dockerfile is to allow you to run with multiple Python versions.  To see the Docker Python images available, visit [Docker Hub](https://hub.docker.com/_/python).  Most of the Linux variants should be usable, but the "alpine" variants will result in the smallest downloads and images.  For example:  
+
+`docker build -t s3cmd-tests --build-arg pyVersion=3.8.1-alpine3.11 -f run-tests.dockerfile .` 
+
+After successfully building the image, you can run it with `docker run --rm s3cmd-tests`.  This will execute the run-tests.py script in the Docker container with your .s3cfg credentials.
+
+Normal `run-tests.py` options may appended.  For example:
+
+`docker run --rm s3cmd-tests --bucket-prefix mytests`
+
+Additional notes:
+
+* If you would like to enter a shell in the container, use `docker run -i -t --rm --entrypoint sh s3cmd-tests`.
+  * `bash` may be specified if you are using a Python image that supports it (not Alpine).
+* If it has been a few days since your last usage, you should check for updates to the upstream Python docker image using `docker pull python` or `docker pull python:3.7` (substituting your desired version)
+* Rebuilding does not over-write a previous image, but instead creates a new image and "untags" the previous one.  Use `docker images` to show all the images on your system, and `docker image prune` to cleanup unused, untagged images.  Please use this command carefully if you have other Docker images on your system.
+* When testing is completed, remove unused Python images with `docker rmi python:3.7`, substituting the tag/version you wish to remove. `docker images` will list the images on your system.

--- a/run-tests.dockerfile
+++ b/run-tests.dockerfile
@@ -1,0 +1,24 @@
+ARG pyVersion=latest
+FROM python:${pyVersion}
+ARG pyVersion
+RUN addgroup testuser \
+  && adduser \
+     --home /home/testuser \
+     --ingroup testuser \
+     --disabled-password \
+     --gecos "" \
+     testuser
+
+USER testuser
+RUN mkdir /home/testuser/src
+WORKDIR /home/testuser/src
+COPY --chown=testuser ./ s3cmd
+COPY --chown=testuser .s3cfg /home/testuser/
+USER root
+WORKDIR /home/testuser/src/s3cmd
+RUN pip install .
+USER testuser
+
+ENTRYPOINT ["python","run-tests.py"]
+
+RUN echo Built with Python version $(python --version)


### PR DESCRIPTION
I'm using this for my testing, and figured it might be useful to other contributors.  At the core, this is just a Dockerfile which will set up an environment to execute run-tests.py.  Because it pulls Python images from Docker Hub, versions of Python can be used that aren't easily accessible to the contributor in other ways.

Note that a valid .s3cfg needs to be copied into the project directory, since Docker cannot copy files from outside it's "context" directory.  For this reason, ".s3cfg" has been added to the .gitignore.

Instructions are in run-tests.docker.README.md, but are copied in here for easy reference and questions if needed.

### Summary

* `docker build -t s3cmd-tests --build-arg pyVersion=3.6 -f run-tests.dockerfile .` - Note the trailing period and substitute your desired Python version as needed.
* `docker run --rm s3cmd-tests`

### More Details

The included run-tests.dockerfile allows contributors to easily test their changes with Python versions that aren't installed locally.

Docker must, of course, be installed on your system if it is not already. See https://docs.docker.com/install/ for instructions.

To begin, build the Dockerfile into an image for the Python version you wish to test against.  The build must be repeated whenever your source changes, but the Python image itself will be cached.  To build:

* Place a valid .s3cfg file in the root project directory.  While .s3cfg has been added to the .gitignore to avoid sending your credentials to public repositories, you should still make sure you remove it when your testing is complete.

* Run `docker build -t s3cmd-tests -f run-tests.dockerfile .` (the trailing period is required)

  This will:

  * Download the latest Python Docker image
  * Add a testuser group and account
  * Copy the .s3cfg into the user's home directory (/home/testuser)
  * Copy the entire project folder into /home/testuser/src/s3cmd
  * Install s3cmd dependencies (as root)

The main purpose of this Dockerfile is to allow you to run with multiple Python versions.  To see the Docker Python images available, visit [Docker Hub](https://hub.docker.com/_/python).  Most of the Linux variants should be usable, but the "alpine" variants will result in the smallest downloads and images.  For example:  

`docker build -t s3cmd-tests --build-arg pyVersion=3.8.1-alpine3.11 -f run-tests.dockerfile .` 

After successfully building the image, you can run it with `docker run --rm s3cmd-tests`.  This will execute the run-tests.py script in the Docker container with your .s3cfg credentials.

Normal `run-tests.py` options may appended.  For example:

`docker run --rm s3cmd-tests --bucket-prefix mytests`

Additional notes:

* If you would like to enter a shell in the container, use `docker run -i -t --rm --entrypoint sh s3cmd-tests`.
  * `bash` may be specified if you are using a Python image that supports it (not Alpine).
* If it has been a few days since your last usage, you should check for updates to the upstream Python docker image using `docker pull python` or `docker pull python:3.7` (substituting your desired version)
* Rebuilding does not over-write a previous image, but instead creates a new image and "untags" the previous one.  Use `docker images` to show all the images on your system, and `docker image prune` to cleanup unused, untagged images.  Please use this command carefully if you have other Docker images on your system.
* When testing is completed, remove unused Python images with `docker rmi python:3.7`, substituting the tag/version you wish to remove. `docker images` will list the images on your system.