### PR TITLE
Fix for Issue #945 ("RuntimeError: dictionary changed size during iteration" when using cache-file)

### DIFF
--- a/S3/HashCache.py
+++ b/S3/HashCache.py
@@ -31,9 +31,9 @@ class HashCache(object):
         return d['md5']
 
     def mark_all_for_purge(self):
-        for d in self.inodes.keys():
-            for i in self.inodes[d].keys():
-                for c in self.inodes[d][i].keys():
+        for d in tuple(self.inodes):
+            for i in tuple(self.inodes[d]):
+                for c in tuple(self.inodes[d][i]):
                     self.inodes[d][i][c]['purge'] = True
 
     def unmark_for_purge(self, dev, inode, mtime, size):
@@ -45,9 +45,9 @@ class HashCache(object):
             del self.inodes[dev][inode][mtime]['purge']
 
     def purge(self):
-        for d in self.inodes.keys():
-            for i in self.inodes[d].keys():
-                for m in self.inodes[d][i].keys():
+        for d in tuple(self.inodes):
+            for i in tuple(self.inodes[d]):
+                for m in tuple(self.inodes[d][i]):
                     if 'purge' in self.inodes[d][i][m]:
                         del self.inodes[d][i]
                         break

--- a/run-tests.py
+++ b/run-tests.py
@@ -377,14 +377,34 @@ test_s3cmd("Invalid bucket name", ["mb", "--bucket-location=EU", pbucket('EU')],
 test_s3cmd("Buckets list", ["ls"],
     must_find = [ "autotest-1", "autotest-2", "Autotest-3" ], must_not_find_re = "autotest-EU")
 
+## ====== Directory for cache
+test_mkdir("Create cache dir","testsuite/cachetest/content")
 
 ## ====== Sync to S3
-test_s3cmd("Sync to S3", ['sync', 'testsuite/', pbucket(1) + '/xyz/', '--exclude', 'demo/*', '--exclude', '*.png', '--no-encrypt', '--exclude-from', 'testsuite/exclude.encodings' ],
+test_s3cmd("Sync to S3", ['sync', 'testsuite/', pbucket(1) + '/xyz/', '--exclude', 'demo/*', '--exclude', '*.png', '--no-encrypt', '--exclude-from', 'testsuite/exclude.encodings','--exclude','testsuite/cachetest/.s3cmdcache', '--cache-file', 'testsuite/cachetest/.s3cmdcache' ],
            must_find = [ "ERROR: Upload of 'testsuite/permission-tests/permission-denied.txt' is not possible (Reason: Permission denied)",
                          "WARNING: 32 non-printable characters replaced in: crappy-file-name/non-printables",
            ],
            must_not_find_re = [ "demo/", "^(?!WARNING: Skipping).*\.png$", "permission-denied-dir" ],
            retcode = EX_PARTIAL)
+
+## ====== Create new file and sync with caching enabled
+f = open("testsuite/cachetest/content/testfile","w")
+f.close()
+test_s3cmd("Sync to S3 with caching", ['sync', 'testsuite/', pbucket(1) + '/xyz/', '--exclude', 'demo/*', '--exclude', '*.png', '--no-encrypt', '--exclude-from', 'testsuite/exclude.encodings','--exclude','cachetest/.s3cmdcache', '--cache-file', 'testsuite/cachetest/.s3cmdcache' ],
+          must_find = "upload: 'testsuite/cachetest/content/testfile' -> '%s/xyz/cachetest/content/testfile'" % pbucket(1),
+          must_not_find = "upload 'testsuite/cachetest/.s3cmdcache'",
+          retcode = EX_PARTIAL)
+
+## ====== Remove content and retry cached sync with --delete-removed
+test_rmdir("Remove local file","testsuite/cachetest/content")
+test_s3cmd("Sync to S3 and delete removed with caching", ['sync', 'testsuite/', pbucket(1) + '/xyz/', '--exclude', 'demo/*', '--exclude', '*.png', '--no-encrypt', '--exclude-from', 'testsuite/exclude.encodings','--exclude','cachetest/.s3cmdcache', '--cache-file', 'testsuite/cachetest/.s3cmdcache', '--delete-removed' ],
+          must_find = "delete: '%s/xyz/cachetest/content/testfile'" % pbucket(1),
+          must_not_find = "dictionary changed size during iteration",
+          retcode = EX_PARTIAL)
+
+## ====== Remove cache directory and file
+test_rmdir("Remove cache dir","testsuite/cachetest")
 
 if have_encoding:
     ## ====== Sync UTF-8 / GBK / ... to S3


### PR DESCRIPTION
Fix for Issue #945 

Apologies for the delay, but here's the discussed fix for the issue.

Also added test cases to run-tests.py for the issue and fix.  It essentially:

* Modifies the first sync test to use a cache-file.  This in-and-of-itself should have no bearing on the success or failure of that particular test; it just sets things up for the following two steps.  The cache file is created in a new subdirectory of testsuite, so that it can be removed afterwards without impacting subsequent tests.
* Creates a file that didn't exist during the first sync.  This is also done in the new subdirectory of testsuite.
* Syncs again, confirming that the file was synced.
* Removes that file and does another sync.  This is the step that would have generated a condition causing the "dictionary changed size" error.  I confirmed that this test fails without the changes to HashCache.py, but passes with them.
* Finally, clean up the subdirectory which contained the cache file.

Tests were run (using the Docker framework I previously submitted in PR#1068) on:

* Python 2.7.17
* Python 3.7.6
* Python 3.8.1

And, of course, PR#1067 should also be merged in order to successfully run all test cases.  Those changes are not included in this PR.