### PR TITLE
Support HTTP-Chunked

### DIFF
--- a/S3/Exceptions.py
+++ b/S3/Exceptions.py
@@ -99,7 +99,6 @@ class S3Error (S3Exception):
         if error_msg:
             retval += (u": %s" % error_msg)
         return retval
-
     def get_error_code(self):
         if self.status in [301, 307]:
             return ExitCodes.EX_SERVERMOVED
@@ -115,7 +114,7 @@ class S3Error (S3Exception):
             return ExitCodes.EX_PRECONDITION
         elif self.status == 500:
             return ExitCodes.EX_SOFTWARE
-        elif self.status in [429, 503]:
+        elif self.status == 503:
             return ExitCodes.EX_SERVICE
         else:
             return ExitCodes.EX_SOFTWARE

--- a/S3/MultiPart.py
+++ b/S3/MultiPart.py
@@ -31,7 +31,8 @@ class MultiPartUpload(object):
         self.dst_uri = dst_uri
         self.parts = {}
         self.headers_baseline = headers_baseline or {}
-
+        if src_size != None:
+           self.headers_baseline['x-multipart-object-size'] = str(self.src_size)
         if isinstance(src, S3UriS3):
             # Source is the uri of an object to s3-to-s3 copy with multipart.
             self.src_uri = src


### PR DESCRIPTION
During the test of our S3 solution, we have experienced an error that it is due mishandling to HTTP chunked mode. Simply s3cmd doesn't support chunked mode by default. This patch is just a couple line of codes to support HTTP-Chunk mode.
Chunked transfer encoding is a streaming data transfer mechanism available in version 1.1 of the Hypertext Transfer Protocol (HTTP). In chunked transfer encoding, the data stream is divided into a series of non-overlapping "chunks". The chunks are sent out and received independently of one another. No knowledge of the data stream outside the currently-being-processed chunk is necessary for both the sender and the receiver at any given time.


	modified:   S3/Exceptions.py
	modified:   S3/MultiPart.py
	modified:   S3/S3.py