### PR TITLE
fix compatibility with Python 3.9

### DIFF
--- a/S3/Exceptions.py
+++ b/S3/Exceptions.py
@@ -127,7 +127,7 @@ class S3Error (S3Exception):
         if not error_node.tag == "Error":
             error_node = tree.find(".//Error")
         if error_node is not None:
-            for child in error_node.getchildren():
+            for child in error_node:
                 if child.text != "":
                     debug("ErrorXML: " + child.tag + ": " + repr(child.text))
                     info[child.tag] = child.text

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -65,9 +65,9 @@ def parseNodes(nodes):
     retval = []
     for node in nodes:
         retval_item = {}
-        for child in node.getchildren():
+        for child in node:
             name = decode_from_s3(child.tag)
-            if child.getchildren():
+            if len(child):
                 retval_item[name] = parseNodes([child])
             else:
                 found_text = node.findtext(".//%s" % child.tag)
@@ -124,8 +124,8 @@ __all__.append("getListFromXml")
 
 def getDictFromTree(tree):
     ret_dict = {}
-    for child in tree.getchildren():
-        if child.getchildren():
+    for child in tree:
+        if len(child):
             ## Complex-type child. Recurse
             content = getDictFromTree(child)
         else:


### PR DESCRIPTION
`getchildren()` method was removed from the `ElementTree` and `Element` classes in Python 3.9. This PR uses built-in `iter()` and `list()` methods instead of the removed one. This fix was suggested in the Python 3.9 release notes:

https://docs.python.org/3.9/whatsnew/3.9.html#removed

I verified this fix on Fedora 33 with Python 3.9.0rc2 by:

```
s3cmd --acl-public sync . s3://...
```