### PR TITLE
Update base64.encodestring for Python 3.9 compatibility

### DIFF
--- a/S3/Crypto.py
+++ b/S3/Crypto.py
@@ -10,7 +10,12 @@ from __future__ import absolute_import
 
 import sys
 import hmac
-import base64
+try:
+    # Python 2 support
+    from base64 import encodestring
+except ImportError:
+    # Python 3.9.0+ support
+    from base64 import encodebytes as encodestring
 
 from . import Config
 from logging import debug
@@ -63,7 +68,7 @@ def sign_string_v2(string_to_sign):
     and returned signature will be utf-8 encoded "bytes".
     """
     secret_key = Config.Config().secret_key
-    signature = base64.encodebytes(hmac.new(encode_to_s3(secret_key), string_to_sign, sha1).digest()).strip()
+    signature = encodestring(hmac.new(encode_to_s3(secret_key), string_to_sign, sha1).digest()).strip()
     return signature
 __all__.append("sign_string_v2")
 

--- a/S3/Crypto.py
+++ b/S3/Crypto.py
@@ -63,7 +63,7 @@ def sign_string_v2(string_to_sign):
     and returned signature will be utf-8 encoded "bytes".
     """
     secret_key = Config.Config().secret_key
-    signature = base64.encodestring(hmac.new(encode_to_s3(secret_key), string_to_sign, sha1).digest()).strip()
+    signature = base64.encodebytes(hmac.new(encode_to_s3(secret_key), string_to_sign, sha1).digest()).strip()
     return signature
 __all__.append("sign_string_v2")
 

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -2054,7 +2054,7 @@ def parse_attrs_header(attrs_header):
 
 def compute_content_md5(body):
     m = md5(encode_to_s3(body))
-    base64md5 = base64.encodestring(m.digest())
+    base64md5 = base64.encodebytes(m.digest())
     base64md5 = decode_from_s3(base64md5)
     if base64md5[-1] == '\n':
         base64md5 = base64md5[0:-1]

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -12,7 +12,6 @@ import sys
 import os
 import time
 import errno
-import base64
 import mimetypes
 import io
 import pprint
@@ -25,6 +24,12 @@ try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
+try:
+    # Python 2 support
+    from base64 import encodestring
+except ImportError:
+    # Python 3.9.0+ support
+    from base64 import encodebytes as encodestring
 
 import select
 
@@ -2054,7 +2059,7 @@ def parse_attrs_header(attrs_header):
 
 def compute_content_md5(body):
     m = md5(encode_to_s3(body))
-    base64md5 = base64.encodebytes(m.digest())
+    base64md5 = encodestring(m.digest())
     base64md5 = decode_from_s3(base64md5)
     if base64md5[-1] == '\n':
         base64md5 = base64md5[0:-1]


### PR DESCRIPTION
`encodestring()` method was removed from base64 in Python 3.9.

See the release notes:  https://docs.python.org/3.9/whatsnew/3.9.html#removed