### PR TITLE
Check self.access_token after set.

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -273,7 +273,8 @@ class Config(object):
                 self.secret_key = secret_key
             if access_token:
                 self.access_token = access_token
-                # Do not refresh the IAM role when an access token is provided.
+            # Do not refresh the IAM role when an access token is provided.
+            if self.access_token:
                 self._access_token_refresh = False
 
             if len(self.access_key)==0:


### PR DESCRIPTION
Afaik, aws cli supports access token to be set in the credential file.
So I have a local cron job that updates access token in `.aws/credentials` and `.s3cfg` file.
By this change, s3cmd won't request a token if it is set in `.s3cfg` or `.aws/credentails` though it is not given by command line