### PR TITLE
fix get bucket info failed when LC use the filter element

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -973,7 +973,7 @@ def cmd_info(args):
                 output(u"   Payer:     %s" % (info['requester-pays']
                                               or 'none'))
                 expiration = s3.expiration_info(uri, cfg.bucket_location)
-                if expiration:
+                if expiration and expiration['prefix'] is not None:
                     expiration_desc = "Expiration Rule: "
                     if expiration['prefix'] == "":
                         expiration_desc += "all objects in this bucket "


### PR DESCRIPTION

configured a bucket lifecycle using the filter element:

```
<?xml version="1.0" ?>
<LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
	<Rule>
		<ID>Rule2</ID>
		<Filter>
			<Tag>
				<Key>test2</Key>
				<Value>test2</Value>
			</Tag>
		</Filter>
		<Status>Enabled</Status>
		<NoncurrentVersionTransition>
			<NoncurrentDays>3</NoncurrentDays>
			<StorageClass>GLACIER</StorageClass>
		</NoncurrentVersionTransition>
	</Rule>
</LifecycleConfiguration>
```

`s3cmd info` failed because there's no Prefix:

```
  File "/usr/bin/s3cmd", line 958, in cmd_info
    expiration_desc += "objects with key prefix '" + expiration['prefix'] + "' "
TypeError: cannot concatenate 'str' and 'NoneType' objects
```

Bypass this failure even if s3cmd doesn't support https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html
