### PR TITLE
Change info of sync command and --no-delete-removed option

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2550,7 +2550,7 @@ def get_commands_list():
     {"cmd":"rm", "label":"Delete file from bucket (alias for del)", "param":"s3://BUCKET/OBJECT", "func":cmd_object_del, "argc":1},
     #{"cmd":"mkdir", "label":"Make a virtual S3 directory", "param":"s3://BUCKET/path/to/dir", "func":cmd_mkdir, "argc":1},
     {"cmd":"restore", "label":"Restore file from Glacier storage", "param":"s3://BUCKET/OBJECT", "func":cmd_object_restore, "argc":1},
-    {"cmd":"sync", "label":"Synchronize a directory tree to S3 (checks files freshness using size and md5 checksum, unless overridden by options, see below)", "param":"LOCAL_DIR s3://BUCKET[/PREFIX] or s3://BUCKET[/PREFIX] LOCAL_DIR", "func":cmd_sync, "argc":2},
+    {"cmd":"sync", "label":"Synchronize a directory tree to S3 (checks files freshness using size and md5 checksum, unless overridden by options, see below)", "param":"LOCAL_DIR s3://BUCKET[/PREFIX] or s3://BUCKET[/PREFIX] LOCAL_DIR or s3://BUCKET[/PREFIX] s3://BUCKET[/PREFIX]", "func":cmd_sync, "argc":2},
     {"cmd":"du", "label":"Disk usage by buckets", "param":"[s3://BUCKET[/PREFIX]]", "func":cmd_du, "argc":0},
     {"cmd":"info", "label":"Get various information about Buckets or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_info, "argc":1},
     {"cmd":"cp", "label":"Copy object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_cp, "argc":2},
@@ -2739,7 +2739,7 @@ def main():
     optparser.add_option(      "--restore-priority", dest="restore_priority", action="store", choices=['standard', 'expedited', 'bulk'], help="Priority for restoring files from S3 Glacier (only for 'restore' command). Choices available: bulk, standard, expedited")
 
     optparser.add_option(      "--delete-removed", dest="delete_removed", action="store_true", help="Delete destination objects with no corresponding source file [sync]")
-    optparser.add_option(      "--no-delete-removed", dest="delete_removed", action="store_false", help="Don't delete destination objects.")
+    optparser.add_option(      "--no-delete-removed", dest="delete_removed", action="store_false", help="Don't delete destination objects [sync]")
     optparser.add_option(      "--delete-after", dest="delete_after", action="store_true", help="Perform deletes AFTER new uploads when delete-removed is enabled [sync]")
     optparser.add_option(      "--delay-updates", dest="delay_updates", action="store_true", help="*OBSOLETE* Put all updated files into place at end [sync]")  # OBSOLETE
     optparser.add_option(      "--max-delete", dest="max_delete", action="store", help="Do not delete more than NUM files. [del] and [sync]", metavar="NUM")

--- a/s3cmd.1
+++ b/s3cmd.1
@@ -49,7 +49,7 @@ Delete file from bucket (alias for del)
 s3cmd \fBrestore\fR \fIs3://BUCKET/OBJECT\fR
 Restore file from Glacier storage
 .TP
-s3cmd \fBsync\fR \fILOCAL_DIR s3://BUCKET[/PREFIX] or s3://BUCKET[/PREFIX] LOCAL_DIR\fR
+s3cmd \fBsync\fR \fILOCAL_DIR s3://BUCKET[/PREFIX] or s3://BUCKET[/PREFIX] LOCAL_DIR or s3://BUCKET[/PREFIX] s3://BUCKET[/PREFIX]\fR
 Synchronize a directory tree to S3 (checks files freshness using size and md5 checksum, unless overridden by options, see below)
 .TP
 s3cmd \fBdu\fR \fI[s3://BUCKET[/PREFIX]]\fR
@@ -276,7 +276,7 @@ Delete destination objects with no corresponding
 source file [sync]
 .TP
 \fB\-\-no\-delete\-removed\fR
-Don't delete destination objects.
+Don't delete destination objects [sync]
 .TP
 \fB\-\-delete\-after\fR
 Perform deletes AFTER new uploads when delete-removed
@@ -524,7 +524,7 @@ Enable verbose output.
 Enable debug output.
 .TP
 \fB\-\-version\fR
-Show s3cmd version (2.1.0) and exit.
+Show s3cmd version (2.1.0+) and exit.
 .TP
 \fB\-F\fR, \fB\-\-follow\-symlinks\fR
 Follow symbolic links as if they are regular files
@@ -539,11 +539,12 @@ Silence output on stdout
 Path to SSL CA certificate FILE (instead of system
 default)
 .TP
-\fB\-\-ssl\-cert\fR=CRT_FILE
+\fB\-\-ssl\-cert\fR=SSL_CLIENT_CERT_FILE
 Path to client own SSL certificate CRT_FILE
 .TP
-\fB\-\-ssl\-key\fR=KEY_FILE
-Path to client own SSL certificate private key KEY_FILE
+\fB\-\-ssl\-key\fR=SSL_CLIENT_KEY_FILE
+Path to client own SSL certificate private key
+KEY_FILE
 .TP
 \fB\-\-check\-certificate\fR
 Check SSL certificate validity


### PR DESCRIPTION
I've updated descriptions of `sync` command and `--no-delete-removed` option and regenerated `s3cmd.1`.
Added remote to remote synchronization params for `sync` according to this code:
https://github.com/s3tools/s3cmd/blob/55597d16937085be3fc8894f23d958241a9aad9f/s3cmd#L1945-L1946
And `--no-delete-removed` can be used only for `sync`.