### PR TITLE
Require at least python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ S3tools / S3cmd mailing lists:
 * General questions and discussion: s3tools-general@lists.sourceforge.net
 * Bug reports: s3tools-bugs@lists.sourceforge.net
 
-S3cmd requires Python 2.6 or newer.
+S3cmd requires Python 2.7 or newer.
 Python 3+ is also supported starting with S3cmd version 2.
 
 See [installation instructions](https://github.com/s3tools/s3cmd/blob/master/INSTALL.md).

--- a/s3cmd
+++ b/s3cmd
@@ -23,8 +23,8 @@ from __future__ import absolute_import, print_function, division
 
 import sys
 
-if sys.version_info < (2, 6):
-    sys.stderr.write(u"ERROR: Python 2.6 or higher required, sorry.\n")
+if sys.version_info < (2, 7):
+    sys.stderr.write(u"ERROR: Python 2.7 or higher required, sorry.\n")
     sys.exit(EX_OSFILE)
 
 PY3 = (sys.version_info >= (3, 0))

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ from setuptools import setup
 
 import S3.PkgInfo
 
-if float("%d.%d" % sys.version_info[:2]) < 2.6:
+if float("%d.%d" % sys.version_info[:2]) < 2.7:
     sys.stderr.write("Your Python version %d.%d.%d is not supported.\n" % sys.version_info[:3])
-    sys.stderr.write("S3cmd requires Python 2.6 or newer.\n")
+    sys.stderr.write("S3cmd requires Python 2.7 or newer.\n")
     sys.exit(1)
 
 ## Remove 'MANIFEST' file to force
@@ -103,7 +103,6 @@ Authors:
         'Operating System :: POSIX',
         'Operating System :: Unix',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',


### PR DESCRIPTION
Tests are run only for Python 2.7, Python 2 itself is no longer supported.
It does not make much sense to support such a old version of languague.