### PR TITLE
Add info about sync defaults

### DIFF
--- a/s3cmd.1
+++ b/s3cmd.1
@@ -50,7 +50,7 @@ s3cmd \fBrestore\fR \fIs3://BUCKET/OBJECT\fR
 Restore file from Glacier storage
 .TP
 s3cmd \fBsync\fR \fILOCAL_DIR s3://BUCKET[/PREFIX] or s3://BUCKET[/PREFIX] LOCAL_DIR or s3://BUCKET[/PREFIX] s3://BUCKET[/PREFIX]\fR
-Synchronize a directory tree to S3 (checks files freshness using size and md5 checksum, unless overridden by options, see below)
+Synchronize a directory tree to S3 (checks files freshness using size and md5 checksum, unless overridden by options, see below) by default it preserves filesysem attributes. See --[no-]preserve for more information.
 .TP
 s3cmd \fBdu\fR \fI[s3://BUCKET[/PREFIX]]\fR
 Disk usage by buckets


### PR DESCRIPTION
Sync by default preserves the file permissions, uid, gid and username in the `x-amz-meta-s3cmd-attrs` meta data field. 
This change documents that. Especially since a lot of people are surprised by this default. 

There was some discussion about this in: https://github.com/s3tools/s3cmd/issues/67