### PR TITLE
Fixes s3cmd#1197 - add custom header for s3cmd mb

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -405,8 +405,11 @@ class S3(object):
         #debug(response)
         return response
 
-    def bucket_create(self, bucket, bucket_location = None):
+    def bucket_create(self, bucket, bucket_location = None, extra_headers = None):
         headers = SortedDict(ignore_case = True)
+        if extra_headers:
+            headers.update(extra_headers)
+
         body = ""
         if bucket_location and bucket_location.strip().upper() != "US" and bucket_location.strip().lower() != "us-east-1":
             bucket_location = bucket_location.strip()

--- a/s3cmd
+++ b/s3cmd
@@ -243,12 +243,13 @@ def subcmd_bucket_list(s3, uri, limit):
 def cmd_bucket_create(args):
     cfg = Config()
     s3 = S3(cfg)
+
     for arg in args:
         uri = S3Uri(arg)
         if not uri.type == "s3" or not uri.has_bucket() or uri.has_object():
             raise ParameterError("Expecting S3 URI with just the bucket name set instead of '%s'" % arg)
         try:
-            response = s3.bucket_create(uri.bucket(), cfg.bucket_location)
+            response = s3.bucket_create(uri.bucket(), cfg.bucket_location, cfg.extra_headers)
             output(u"Bucket '%s' created" % uri.uri())
         except S3Error as e:
             if e.info["Code"] in S3.codes:


### PR DESCRIPTION
In the Cloudian Hyperstore S3 software stack (www.cloudian.com) bucket creation can take an extra header to specify a storage policy id.

`s3cmd mb` silently ignores custom headers as specified with the `--add-header` option.

s3cmd and S3/S3.py updated to pass custom header to the S3 stack.