### PR TITLE
add --no-remote-copy to upload files every instance.

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -211,6 +211,7 @@ class Config(object):
     throttle_max = 100
     public_url_use_https = False
     connection_pooling = True
+    remote_copy = True
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None, access_token=None):

--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -597,7 +597,10 @@ def compare_filelists(src_list, dst_list, src_remote, dst_remote):
             else:
                 # look for matching file in src
                 try:
-                    md5 = src_list.get_md5(relative_file)
+                    if cfg.remote_copy:
+                        md5 = src_list.get_md5(relative_file)
+                    else:
+                        md5 = None
                 except IOError:
                     md5 = None
                 if md5 is not None and md5 in dst_list.by_md5:
@@ -621,8 +624,11 @@ def compare_filelists(src_list, dst_list, src_remote, dst_remote):
             try:
                 md5 = src_list.get_md5(relative_file)
             except IOError:
-               md5 = None
-            dst1 = dst_list.find_md5_one(md5)
+                md5 = None
+            if cfg.remote_copy:
+                dst1 = dst_list.find_md5_one(md5)
+            else:
+                dst1 = None
             if dst1 is not None:
                 # Found one, we want to copy
                 debug(u"DST COPY dst: %s -> %s" % (dst1, relative_file))

--- a/s3cmd
+++ b/s3cmd
@@ -2780,6 +2780,7 @@ def main():
     optparser.add_option(      "--stop-on-error", dest="stop_on_error", action="store_true", help="stop if error in transfer")
     optparser.add_option(      "--content-disposition", dest="content_disposition", action="store", help="Provide a Content-Disposition for signed URLs, e.g., \"inline; filename=myvideo.mp4\"")
     optparser.add_option(      "--content-type", dest="content_type", action="store", help="Provide a Content-Type for signed URLs, e.g., \"video/mp4\"")
+    optparser.add_option(      "--no-remote-copy", dest="remote_copy", action="store_false", default=True, help="Disable remote copy for duplicate files. Upload each file.")
 
     optparser.set_usage(optparser.usage + " COMMAND [parameters]")
     optparser.set_description('S3cmd is a tool for managing objects in '+
@@ -3004,6 +3005,8 @@ def main():
 
     if options.content_type:
         cfg.content_type = options.content_type
+
+    cfg.remote_copy = options.remote_copy
 
     if len(args) < 1:
         optparser.print_help()

--- a/s3cmd.1
+++ b/s3cmd.1
@@ -580,6 +580,9 @@ Provide a Content\-Disposition for signed URLs, e.g.,
 \fB\-\-content\-type\fR=CONTENT_TYPE
 Provide a Content\-Type for signed URLs, e.g.,
 "video/mp4"
+.TP
+\fB\-\-no\-remote\-copy
+s3cmd will not optimize uploads of the same file.  Content will be upload once for each file.
 
 
 .SH EXAMPLES


### PR DESCRIPTION
S3cmd will optimize the uploaded data so that multiple files with the same data are uploaded only once.  Normally, this is a good thing.  We are expecting that the files would also have the same e-tag.  Since they are larger than our chunk size, they have the multipart e-tag with the '-n' suffix.  When s3cmd does the remote->remote copy of a file, aws uses a different mechanism to copy.  The result is the e-tags do not agree.  They are both correct, but they do not agree.  This PR adds and option --no-remote-copy that inhibits s3cmd from optimizing the upload. Thereby, all e-tags are the same.