### PR TITLE
removed a default mutable argument pitfall

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -148,7 +148,18 @@ if not os.path.isdir('testsuite/crappy-file-name'):
     # TODO: also unpack if the tarball is newer than the directory timestamp
     #       for instance when a new version was pulled from SVN.
 
-def test(label, cmd_args = [], retcode = 0, must_find = [], must_not_find = [], must_find_re = [], must_not_find_re = [], stdin = None):
+def validate_default_mutable_arg(argument):
+    if argument:
+        return argument
+    else:
+        return []
+
+def test(label, cmd_args = None, retcode = 0, must_find = None, must_not_find = None, must_find_re = None, must_not_find_re = None, stdin = None):
+    cmd_args = validate_default_mutable_arg(cmd_args)
+    must_find = validate_default_mutable_arg(must_find)
+    must_not_find = validate_default_mutable_arg(must_not_find)
+    must_find_re = validate_default_mutable_arg(must_find_re)
+    must_not_find_re = validate_default_mutable_arg(must_not_find_re)
     def command_output():
         print("----")
         print(" ".join([" " in arg and "'%s'" % arg or arg for arg in cmd_args]))


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in methods, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument