### PR TITLE
List support of Python 3.9 and 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,8 @@ Authors:
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: System :: Archiving',
         'Topic :: Utilities',
     ],


### PR DESCRIPTION
Updated `setup.py` to list 3.9 and 3.10 (3.10 is passing the test suite so I assume it works fine)