### PR TITLE
bugfix: --exclude dir/ walks inside dir/ for python 3.6+

### DIFF
--- a/run-tests.py
+++ b/run-tests.py
@@ -686,6 +686,14 @@ test_s3cmd("Sync remote2remote", ['sync', '%s/xyz/' % pbucket(1), '%s/copy/' % p
                   "delete: '%s/copy/etc/logo.png'" % pbucket(2) ],
     must_not_find = [ "blah.txt" ])
 
+## ====== Exclude directory
+test_s3cmd("Exclude directory", ['put', '-r', 'testsuite/demo/', pbucket(1) + '/xyz/demo/', '--exclude', 'dir1/', '-d'],
+           must_find = ["'testsuite/demo/dir2/file2-1.bin' -> '%s/xyz/demo/dir2/file2-1.bin'" % pbucket(1),
+                        "DEBUG: EXCLUDE: 'testsuite/demo/dir1/'"],  # whole directory is excluded
+           must_not_find = ["'testsuite/demo/dir1/file1-1.txt' -> '%s/xyz/demo/dir1/file1-1.txt'" % pbucket(1),
+                            "DEBUG: EXCLUDE: dir1/file1-1.txt"  # file is not synced, but also single file is not excluded
+                           ])
+
 ## ====== Don't Put symbolic link
 test_s3cmd("Don't put symbolic links", ['put', 'testsuite/etc/linked1.png', 's3://%s/xyz/' % bucket(1),],
            retcode = EX_USAGE,


### PR DESCRIPTION
I found out that `--ecxlude dir/` does not work properly on my system (Ubuntu 18.04 + python3.8) since it does not prevent from recursive scanning of all files inside excluded directory, which makes backuping big filesystems completely impossible. 

Here is why it happens:
see https://docs.python.org/3.5/library/fnmatch.html
```
>>> regex = fnmatch.translate('*.txt')
>>> regex
'.*\\.txt\\Z(?ms)'
```
compare with https://docs.python.org/3.6/library/fnmatch.html 
```
>>> regex = fnmatch.translate('*.txt')
>>> regex
'(?s:.*\\.txt)\\Z'
```
This change produces new regexp pattern for `--exclude dir/` which was not handled in FileLists.handle_exclude_include_walk_dir().

It's clear that program is broken and current behaviour is not expected:
1) function FileLists.handle_exclude_include_walk_dir doesn't do anything on python 3.6+
2) this comment https://github.com/s3tools/s3cmd/issues/212#issuecomment-32579310 says _"We absolutely need to be able to prune directories from the os.walk() via excludes."_

PR includes:
- fix the problem by adding new regexp pattern
- add test for that case