### PR TITLE
Take into account the AWS_STS_REGIONAL_ENDPOINTS

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -318,7 +318,15 @@ class Config(object):
                     '%s=%s' % (k, s3_quote(v, unicode_output=True))
                     for k, v in params.items()
                 ])
-                conn = httplib.HTTPSConnection(host='sts.amazonaws.com',
+                sts_endpoint = "sts.amazonaws.com"
+                if os.environ.get("AWS_STS_REGIONAL_ENDPOINTS") == "regional": 
+                    # Check if the AWS_REGION variable is available to use as a region. 
+                    region = os.environ.get("AWS_REGION")
+                    if not region: 
+                        # Otherwise use the bucket location
+                        region = self.bucket_location
+                    sts_endpoint = "sts.%s.amazonaws.com" % region 
+                conn = httplib.HTTPSConnection(host=sts_endpoint,
                                                timeout=2)
                 conn.request('POST', '/?' + encoded_params)
                 resp = conn.getresponse()


### PR DESCRIPTION
This fixes the issue where the sts endpoint sts.amazonaws.com is not
accessible.
Take into account the environment varialbe AWS_STS_REGIONAL_ENDPOINTS
If the AWS_STS_REGIONAL_ENDPOINTS variable is provided check for AWS_REGION env var to decide
region.

If AWS_REGION is not provided use the same region as the bucket.
(bucket_location parameter)