### PR TITLE
Add FIPS support

### DIFF
--- a/S3/BaseUtils.py
+++ b/S3/BaseUtils.py
@@ -8,6 +8,8 @@
 
 from __future__ import absolute_import, division
 
+import functools
+import hashlib
 import re
 import sys
 
@@ -48,6 +50,19 @@ except NameError:
     # python 3 support
     # In python 3, unicode -> str, and str -> bytes
     unicode = str
+
+
+try:
+   md5 = hashlib.md5()
+except Exception as exc:
+  try:
+    # md5 is disabled for FIPS-compliant Python builds.
+    # Since s3cmd does not use md5 in a security context,
+    # it is safe to allow the use of it by setting useforsecurity to False.
+    hashlib.md5(usedforsecurity=False)
+    md5 = functools.partial(hashlib.md5, usedforsecurity=False)
+  except:
+      raise exc
 
 
 __all__ = []

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -33,13 +33,8 @@ except ImportError:
 
 import select
 
-try:
-    from hashlib import md5
-except ImportError:
-    from md5 import md5
-
 from .BaseUtils import (getListFromXml, getTextFromXml, getRootTagName,
-                        decode_from_s3, encode_to_s3, s3_quote)
+                        decode_from_s3, encode_to_s3, md5, s3_quote)
 from .Utils import (convertHeaderTupleListToDict, hash_file_md5, unicodise,
                     deunicodise, check_bucket_name,
                     check_bucket_name_dns_support, getHostnameFromBucket,
@@ -1647,10 +1642,7 @@ class S3(object):
                 raise S3UploadError("Upload failed for: %s" % resource['uri'])
         if buffer == '':
             stream.seek(offset)
-        try:
-          md5_hash = md5()
-        except Exception:
-          md5_hash = md5(usedforsecurity=False)
+        md5_hash = md5()
 
         try:
             http_response = None
@@ -1953,10 +1945,7 @@ class S3(object):
         if start_position == 0:
             # Only compute MD5 on the fly if we're downloading from beginning
             # Otherwise we'd get a nonsense.
-            try:
-              md5_hash = md5()
-            except Exception:
-              md5_hash = md5(usedforsecurity=False)
+            md5_hash = md5()
         size_left = int(response["headers"]["content-length"])
         size_total = start_position + size_left
         current_position = start_position
@@ -2075,10 +2064,7 @@ def parse_attrs_header(attrs_header):
     return attrs
 
 def compute_content_md5(body):
-    try:
-      m = md5(encode_to_s3(body))
-    except Exception:
-      m = md5(encode_to_s3(body), usedforsecurity=False)
+    m = md5(encode_to_s3(body))
     base64md5 = encodestring(m.digest())
     base64md5 = decode_from_s3(base64md5)
     if base64md5[-1] == '\n':

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1647,7 +1647,10 @@ class S3(object):
                 raise S3UploadError("Upload failed for: %s" % resource['uri'])
         if buffer == '':
             stream.seek(offset)
-        md5_hash = md5()
+        try:
+          md5_hash = md5()
+        except Exception:
+          md5_hash = md5(usedforsecurity=False)
 
         try:
             http_response = None
@@ -1950,7 +1953,10 @@ class S3(object):
         if start_position == 0:
             # Only compute MD5 on the fly if we're downloading from beginning
             # Otherwise we'd get a nonsense.
-            md5_hash = md5()
+            try:
+              md5_hash = md5()
+            except Exception:
+              md5_hash = md5(usedforsecurity=False)
         size_left = int(response["headers"]["content-length"])
         size_total = start_position + size_left
         current_position = start_position
@@ -2069,7 +2075,10 @@ def parse_attrs_header(attrs_header):
     return attrs
 
 def compute_content_md5(body):
-    m = md5(encode_to_s3(body))
+    try:
+      m = md5(encode_to_s3(body))
+    except Exception:
+      m = md5(encode_to_s3(body), usedforsecurity=False)
     base64md5 = encodestring(m.digest())
     base64md5 = decode_from_s3(base64md5)
     if base64md5[-1] == '\n':

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -102,7 +102,10 @@ __all__.append("mktmpfile")
 
 
 def hash_file_md5(filename):
-    h = md5()
+    try:
+      h = md5()
+    except Exception:
+      h = md5(usedforsecurity=False)
     with open(deunicodise(filename), "rb") as fp:
         while True:
             # Hash 32kB chunks
@@ -310,7 +313,10 @@ __all__.append("getHostnameFromBucket")
 
 
 def calculateChecksum(buffer, mfile, offset, chunk_size, send_chunk):
-    md5_hash = md5()
+    try:
+      md5_hash = md5()
+    except Exception:
+      md5_hash = md5(usedforsecurity=False)
     size_left = chunk_size
     if buffer == '':
         mfile.seek(offset)

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -14,7 +14,6 @@ import re
 import string as string_mod
 import random
 import errno
-from hashlib import md5
 from logging import debug
 
 
@@ -30,7 +29,7 @@ import S3.Config
 import S3.Exceptions
 
 from S3.BaseUtils import (base_urlencode_string, base_replace_nonprintables,
-                          base_unicodise, base_deunicodise)
+                          base_unicodise, base_deunicodise, md5)
 
 
 __all__ = []
@@ -102,10 +101,7 @@ __all__.append("mktmpfile")
 
 
 def hash_file_md5(filename):
-    try:
-      h = md5()
-    except Exception:
-      h = md5(usedforsecurity=False)
+    h = md5()
     with open(deunicodise(filename), "rb") as fp:
         while True:
             # Hash 32kB chunks
@@ -313,10 +309,7 @@ __all__.append("getHostnameFromBucket")
 
 
 def calculateChecksum(buffer, mfile, offset, chunk_size, send_chunk):
-    try:
-      md5_hash = md5()
-    except Exception:
-      md5_hash = md5(usedforsecurity=False)
+    md5_hash = md5()
     size_left = chunk_size
     if buffer == '':
         mfile.seek(offset)


### PR DESCRIPTION
When FIPS mode is enabled, s3cmd raises a ValueError exception with the message 'digital envelope routines: EVP_DigestInit_ex] disabled for FIPS' (see below). This change will make s3cmd compatible with FIPS mode.

```
$ fips-mode-setup --check
FIPS mode is enabled.

$ s3cmd put ...
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    An unexpected error has occurred.
  ...
Problem: <class 'ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS
S3cmd:   2.2.0
python:   3.6.8 (default, Jan 19 2022, 23:28:49) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-7)]
environment LANG=en_US.UTF-8
Traceback (most recent call last):
  File "./s3cmd/s3cmd", line 3209, in <module>
    rc = main()
  File "./s3cmd/s3cmd", line 3106, in main
    rc = cmd_func(args)
  File "./s3cmd/s3cmd", line 392, in cmd_object_put
    local_list, single_file_local, exclude_list, total_size_local = fetch_local_list(args, is_src = True)
  File "/home/michaelroth/s3cmd/S3/FileLists.py", line 367, in fetch_local_list
    total_size = _fetch_local_list_info(local_list)
  File "/home/michaelroth/s3cmd/S3/FileLists.py", line 238, in _fetch_local_list_info
    md5 = loc_list.get_md5(relative_file) # this does the file I/O
  File "/home/michaelroth/s3cmd/S3/FileDict.py", line 48, in get_md5
    md5 = Utils.hash_file_md5(self[relative_file]['full_name'])
  File "/home/michaelroth/s3cmd/S3/Utils.py", line 105, in hash_file_md5
    h = md5()
ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS
```