### PR TITLE
excepting/handling tcp connection refused error

### DIFF
--- a/S3/ExitCodes.py
+++ b/S3/ExitCodes.py
@@ -2,27 +2,28 @@
 
 # patterned on /usr/include/sysexits.h
 
-EX_OK               = 0
-EX_GENERAL          = 1
-EX_PARTIAL          = 2    # some parts of the command succeeded, while others failed
-EX_SERVERMOVED      = 10   # 301: Moved permanantly & 307: Moved temp
-EX_SERVERERROR      = 11   # 400, 405, 411, 416, 417, 501: Bad request, 504: Gateway Time-out
-EX_NOTFOUND         = 12   # 404: Not found
-EX_CONFLICT         = 13   # 409: Conflict (ex: bucket error)
-EX_PRECONDITION     = 14   # 412: Precondition failed
-EX_SERVICE          = 15   # 503: Service not available or slow down
-EX_USAGE            = 64   # The command was used incorrectly (e.g. bad command line syntax)
-EX_DATAERR          = 65   # Failed file transfer, upload or download
-EX_SOFTWARE         = 70   # internal software error (e.g. S3 error of unknown specificity)
-EX_OSERR            = 71   # system error (e.g. out of memory)
-EX_OSFILE           = 72   # OS error (e.g. invalid Python version)
-EX_IOERR            = 74   # An error occurred while doing I/O on some file.
-EX_TEMPFAIL         = 75   # temporary failure (S3DownloadError or similar, retry later)
-EX_ACCESSDENIED     = 77   # Insufficient permissions to perform the operation on S3
-EX_CONFIG           = 78   # Configuration file error
-_EX_SIGNAL          = 128
-_EX_SIGINT          = 2
-EX_BREAK            = _EX_SIGNAL + _EX_SIGINT # Control-C (KeyboardInterrupt raised)
+EX_OK                = 0
+EX_GENERAL           = 1
+EX_PARTIAL           = 2    # some parts of the command succeeded, while others failed
+EX_SERVERMOVED       = 10   # 301: Moved permanantly & 307: Moved temp
+EX_SERVERERROR       = 11   # 400, 405, 411, 416, 417, 501: Bad request, 504: Gateway Time-out
+EX_NOTFOUND          = 12   # 404: Not found
+EX_CONFLICT          = 13   # 409: Conflict (ex: bucket error)
+EX_PRECONDITION      = 14   # 412: Precondition failed
+EX_SERVICE           = 15   # 503: Service not available or slow down
+EX_USAGE             = 64   # The command was used incorrectly (e.g. bad command line syntax)
+EX_DATAERR           = 65   # Failed file transfer, upload or download
+EX_SOFTWARE          = 70   # internal software error (e.g. S3 error of unknown specificity)
+EX_OSERR             = 71   # system error (e.g. out of memory)
+EX_OSFILE            = 72   # OS error (e.g. invalid Python version)
+EX_IOERR             = 74   # An error occurred while doing I/O on some file.
+EX_TEMPFAIL          = 75   # temporary failure (S3DownloadError or similar, retry later)
+EX_ACCESSDENIED      = 77   # Insufficient permissions to perform the operation on S3
+EX_CONFIG            = 78   # Configuration file error
+EX_CONNECTIONREFUSED = 111  # TCP connection refused (e.g. connecting to a closed server port)
+_EX_SIGNAL           = 128
+_EX_SIGINT           = 2
+EX_BREAK             = _EX_SIGNAL + _EX_SIGINT # Control-C (KeyboardInterrupt raised)
 
 class ExitScoreboard(object):
     """Helper to return best return code"""

--- a/s3cmd
+++ b/s3cmd
@@ -3241,6 +3241,12 @@ if __name__ == '__main__':
         error("SSL certificate verification failure: %s" % e)
         sys.exit(EX_ACCESSDENIED)
 
+    except ConnectionRefusedError as e:
+        error(e)
+        sys.exit(EX_CONNECTIONREFUSED)
+        # typically encountered error is:
+        # ERROR: [Errno 111] Connection refused
+
     except socket.gaierror as e:
         # gaierror is a subset of IOError
         # typically encountered error is:


### PR DESCRIPTION
When TCP connection refuses, you get this non-handled error at socket client layer:
```
  File "/home/salar/foss/s3cmd/S3/S3.py", line 326, in list_all_buckets
    response = self.send_request(request)
  File "/home/salar/foss/s3cmd/S3/S3.py", line 1480, in send_request
    conn = ConnMan.get(self.get_hostname(resource['bucket']))
  File "/home/salar/foss/s3cmd/S3/ConnMan.py", line 284, in get
    conn.c.connect()
  File "/usr/lib/python3.10/http/client.py", line 941, in connect
    self.sock = self._create_connection(
  File "/usr/lib/python3.10/socket.py", line 845, in create_connection
    raise err
  File "/usr/lib/python3.10/socket.py", line 833, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```

I tried to handle this error message with expecting when running main function and exit with 111 ECONNREFUSED exit code.
Also I've added this exit code to S3 library.
the command result is something like that:
ERROR: [Errno 111] Connection refused

Update: the error name "ECONNREFUSED" and it's error code is not listed in ```/usr/include/sysexits.h``` . but its a specified POSIX error name. you can find it at [errorno manual](https://man7.org/linux/man-pages/man3/errno.3.html), [MariaDB knowledgebase](https://mariadb.com/kb/en/operating-system-error-codes/) and even on ```ConnectionRefused.errorno```.

Thanks

