### PR TITLE
Improve error messages when S3 returns a 403 error during an `ls` operation

### DIFF
--- a/S3/Exceptions.py
+++ b/S3/Exceptions.py
@@ -136,6 +136,20 @@ class S3Error (S3Exception):
             raise S3ResponseError("Malformed error XML returned from remote server.")
         return info
 
+class S3AccessDenied(S3Error):
+    def __init__(self, resource, response):
+        super(S3AccessDenied, self).__init__(response)
+        self.resource = resource
+        debug("S3AccessDenied: %s (%s): %s" % (self.status, self.reason, self.resource))
+
+    def __unicode__(self):
+        retval = u"%d " % (self.status)
+        retval += (u"(%s)" % (self.code or self.reason))
+        error_msg = self.message
+        if error_msg:
+            retval += (u": %s" % error_msg)
+        retval += (u": %s" % (self.resource))
+        return retval
 
 class CloudFrontError(S3Error):
     pass

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1469,7 +1469,7 @@ class S3(object):
                         self.fallback_to_signature_v2 = True
                         return fn(*args, **kwargs)
 
-        raise S3Error(response)
+        raise S3AccessDenied(request.resource, response)
 
     def update_region_inner_request(self, request):
         """Get and update region for the request if needed.


### PR DESCRIPTION
Include the bucket name and URI in the logged error message (via the exception object).

Before:

    ERROR: S3 error: 403 (Forbidden)

After:

    ERROR: S3 error: 403 (Forbidden): {'bucket': 'iPhoto....net', 'uri': '/.../Masters/2016/10/15/20161015-142339/IMG_3290.MOV'}