### PR TITLE
add `--skip-destination-validation` option for `setnotification`

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -223,6 +223,7 @@ class Config(object):
     expiry_days = u""
     expiry_date = u""
     expiry_prefix = u""
+    skip_destination_validation = False
     signature_v2 = False
     limitrate = 0
     requester_pays = False

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1159,8 +1159,11 @@ class S3(object):
         return response
 
     def set_notification_policy(self, uri, policy):
+        headers = SortedDict(ignore_case = True)
+        if self.config.skip_destination_validation:
+            headers["x-amz-skip-destination-validation"] = "True"
         request = self.create_request("BUCKET_CREATE", uri = uri,
-                                      body = policy,
+                                      headers = headers, body = policy,
                                       uri_params = {'notification': None})
         debug(u"set_notification_policy(%s): policy-xml: %s" % (uri, policy))
         response = self.send_request(request)

--- a/s3cmd
+++ b/s3cmd
@@ -2892,7 +2892,7 @@ def main():
     optparser.add_option(      "--expiry-days", dest="expiry_days", action="store", help="Indicates the number of days after object creation the expiration rule takes effect. (only for [expire] command)")
     optparser.add_option(      "--expiry-prefix", dest="expiry_prefix", action="store", help="Identifying one or more objects with the prefix to which the expiration rule applies. (only for [expire] command)")
 
-    optparser.add_option(      "--skip-destination-validation", dest="skip_destination_validation", action="store_true", help="Skips validation of Amazon SQS, Amazon SNS, and AWS Lambda destinations when applying notification configuration.")
+    optparser.add_option(      "--skip-destination-validation", dest="skip_destination_validation", action="store_true", help="Skips validation of Amazon SQS, Amazon SNS, and AWS Lambda destinations when applying notification configuration. (only for [setnotification] command)")
 
     optparser.add_option(      "--progress", dest="progress_meter", action="store_true", help="Display progress meter (default on TTY).")
     optparser.add_option(      "--no-progress", dest="progress_meter", action="store_false", help="Don't display progress meter (default on non-TTY).")

--- a/s3cmd
+++ b/s3cmd
@@ -2892,6 +2892,8 @@ def main():
     optparser.add_option(      "--expiry-days", dest="expiry_days", action="store", help="Indicates the number of days after object creation the expiration rule takes effect. (only for [expire] command)")
     optparser.add_option(      "--expiry-prefix", dest="expiry_prefix", action="store", help="Identifying one or more objects with the prefix to which the expiration rule applies. (only for [expire] command)")
 
+    optparser.add_option(      "--skip-destination-validation", dest="skip_destination_validation", action="store_true", help="Skips validation of Amazon SQS, Amazon SNS, and AWS Lambda destinations when applying notification configuration.")
+
     optparser.add_option(      "--progress", dest="progress_meter", action="store_true", help="Display progress meter (default on TTY).")
     optparser.add_option(      "--no-progress", dest="progress_meter", action="store_false", help="Don't display progress meter (default on non-TTY).")
     optparser.add_option(      "--stats", dest="stats", action="store_true", help="Give some file-transfer stats.")


### PR DESCRIPTION
According to AWS spec for PutBucketNotificationConfiguration API, 
```
x-amz-skip-destination-validation

Skips validation of Amazon SQS, Amazon SNS, and AWS Lambda destinations. True or false value.
```
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketNotificationConfiguration.html#AmazonS3-PutBucketNotificationConfiguration-request-header-SkipDestinationValidation
