### PR TITLE
Support versioning configuration

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -251,6 +251,7 @@ class Config(object):
     list_allow_unordered = False
     # Maximum attempts of re-issuing failed requests
     max_retries = 5
+    versioning_suspended = False
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None, access_token=None):

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -251,7 +251,6 @@ class Config(object):
     list_allow_unordered = False
     # Maximum attempts of re-issuing failed requests
     max_retries = 5
-    versioning_suspended = False
 
     ## Creating a singleton
     def __new__(self, configfile = None, access_key=None, secret_key=None, access_token=None):

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -481,7 +481,10 @@ class S3(object):
             response['requester-pays'] = self.get_bucket_requester_pays(uri)
         except S3Error as e:
             response['requester-pays'] = None
-        response['versioning'] = self.get_versioning(uri)
+        try:
+            response['versioning'] = self.get_versioning(uri)
+        except S3Error as e:
+            response['versioning'] = None
         return response
 
     def website_info(self, uri, bucket_location = None):
@@ -1065,12 +1068,12 @@ class S3(object):
         response = self.send_request(request)
         return response
 
-    def set_versioning(self, uri, status):
+    def set_versioning(self, uri, enabled):
         headers = SortedDict(ignore_case = True)
-        headers['content-type'] = 'application/xml'
-        body = '<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\n'
-        body += '<Status>%s</Status>\n' % status
-        body += '</VersioningConfiguration>\n'
+        status = "Enabled" if enabled is True else "Suspended"
+        body = '<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        body += '<Status>%s</Status>' % status
+        body += '</VersioningConfiguration>'
         debug(u"set_versioning(%s)" % body)
         headers['content-md5'] = compute_content_md5(body)
         request = self.create_request("BUCKET_CREATE", uri = uri,

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -481,6 +481,7 @@ class S3(object):
             response['requester-pays'] = self.get_bucket_requester_pays(uri)
         except S3Error as e:
             response['requester-pays'] = None
+        response['versioning'] = self.get_versioning(uri)
         return response
 
     def website_info(self, uri, bucket_location = None):
@@ -1063,6 +1064,27 @@ class S3(object):
 
         response = self.send_request(request)
         return response
+
+    def set_versioning(self, uri, status):
+        headers = SortedDict(ignore_case = True)
+        headers['content-type'] = 'application/xml'
+        body = '<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">\n'
+        body += '<Status>%s</Status>\n' % status
+        body += '</VersioningConfiguration>\n'
+        debug(u"set_versioning(%s)" % body)
+        headers['content-md5'] = compute_content_md5(body)
+        request = self.create_request("BUCKET_CREATE", uri = uri,
+                                      headers = headers, body = body,
+                                      uri_params = {'versioning': None})
+        response = self.send_request(request)
+        return response
+
+    def get_versioning(self, uri):
+        request = self.create_request("BUCKET_LIST", uri = uri,
+                                      uri_params = {'versioning': None})
+        response = self.send_request(request)
+
+        return getTextFromXml(response['data'], "Status")
 
     def get_policy(self, uri):
         request = self.create_request("BUCKET_LIST", bucket = uri.bucket(),

--- a/s3cmd
+++ b/s3cmd
@@ -1023,6 +1023,8 @@ def cmd_info(args):
                                               or 'none'))
                 output(u"   Payer:     %s" % (info['requester-pays']
                                               or 'none'))
+                output(u"   Versioning:%s" % (info['versioning']
+                                              or 'none'))
                 expiration = s3.expiration_info(uri, cfg.bucket_location)
                 if expiration and expiration['prefix'] is not None:
                     expiration_desc = "Expiration Rule: "
@@ -2047,6 +2049,20 @@ def cmd_setacl(args):
         update_acl(s3, uri, seq_label)
     return EX_OK
 
+def cmd_setversioning(args):
+    cfg = Config()
+    s3 = S3(cfg)
+    uri = S3Uri(args[0])
+
+    status = cfg.versioning_suspended and "Suspended" or "Enabled"
+
+    response = s3.set_versioning(uri, status)
+
+    debug(u"response - %s" % response['status'])
+    if response['status'] == 200:
+        output(u"%s: Versioning status updated" % uri)
+    return EX_OK
+
 def cmd_setpolicy(args):
     cfg = Config()
     s3 = S3(cfg)
@@ -2649,6 +2665,7 @@ def get_commands_list():
     {"cmd":"modify", "label":"Modify object metadata", "param":"s3://BUCKET1/OBJECT", "func":cmd_modify, "argc":1},
     {"cmd":"mv", "label":"Move object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_mv, "argc":2},
     {"cmd":"setacl", "label":"Modify Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_setacl, "argc":1},
+    {"cmd":"setversioning", "label":"Modify Bucket Versioning", "param":"s3://BUCKET", "func":cmd_setversioning, "argc":1},
 
     {"cmd":"setpolicy", "label":"Modify Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_setpolicy, "argc":2},
     {"cmd":"delpolicy", "label":"Delete Bucket Policy", "param":"s3://BUCKET", "func":cmd_delpolicy, "argc":1},
@@ -2937,6 +2954,7 @@ def main():
     optparser.add_option(      "--max-retries", dest="max_retries", action="store", help="Maximum number of times to retry a failed request before giving up. Default is 5", metavar="NUM")
     optparser.add_option(      "--content-disposition", dest="content_disposition", action="store", help="Provide a Content-Disposition for signed URLs, e.g., \"inline; filename=myvideo.mp4\"")
     optparser.add_option(      "--content-type", dest="content_type", action="store", help="Provide a Content-Type for signed URLs, e.g., \"video/mp4\"")
+    optparser.add_option(      "--versioning-suspended", dest="versioning_suspended", action="store_true", help="Set bucket versioning status. (only for [setversioning] command)")
 
     optparser.set_usage(optparser.usage + " COMMAND [parameters]")
     optparser.set_description('S3cmd is a tool for managing objects in '+

--- a/s3cmd
+++ b/s3cmd
@@ -2052,15 +2052,19 @@ def cmd_setacl(args):
 def cmd_setversioning(args):
     cfg = Config()
     s3 = S3(cfg)
-    uri = S3Uri(args[0])
+    bucket_uri = S3Uri(args[0])
+    if bucket_uri.object():
+        raise ParameterError("Only bucket name is required for [setversioning] command")
+    status = args[1]
+    if status not in ["enable", "disable"]:
+        raise ParameterError("Must be 'enable' or 'disable'. Got: %s" % status)
 
-    status = cfg.versioning_suspended and "Suspended" or "Enabled"
-
-    response = s3.set_versioning(uri, status)
+    enabled = True if status == "enable" else False
+    response = s3.set_versioning(bucket_uri, enabled)
 
     debug(u"response - %s" % response['status'])
     if response['status'] == 200:
-        output(u"%s: Versioning status updated" % uri)
+        output(u"%s: Versioning status updated" % bucket_uri)
     return EX_OK
 
 def cmd_setpolicy(args):
@@ -2665,7 +2669,7 @@ def get_commands_list():
     {"cmd":"modify", "label":"Modify object metadata", "param":"s3://BUCKET1/OBJECT", "func":cmd_modify, "argc":1},
     {"cmd":"mv", "label":"Move object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_mv, "argc":2},
     {"cmd":"setacl", "label":"Modify Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_setacl, "argc":1},
-    {"cmd":"setversioning", "label":"Modify Bucket Versioning", "param":"s3://BUCKET", "func":cmd_setversioning, "argc":1},
+    {"cmd":"setversioning", "label":"Modify Bucket Versioning", "param":"s3://BUCKET enable|disable", "func":cmd_setversioning, "argc":2},
 
     {"cmd":"setpolicy", "label":"Modify Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_setpolicy, "argc":2},
     {"cmd":"delpolicy", "label":"Delete Bucket Policy", "param":"s3://BUCKET", "func":cmd_delpolicy, "argc":1},
@@ -2954,7 +2958,6 @@ def main():
     optparser.add_option(      "--max-retries", dest="max_retries", action="store", help="Maximum number of times to retry a failed request before giving up. Default is 5", metavar="NUM")
     optparser.add_option(      "--content-disposition", dest="content_disposition", action="store", help="Provide a Content-Disposition for signed URLs, e.g., \"inline; filename=myvideo.mp4\"")
     optparser.add_option(      "--content-type", dest="content_type", action="store", help="Provide a Content-Type for signed URLs, e.g., \"video/mp4\"")
-    optparser.add_option(      "--versioning-suspended", dest="versioning_suspended", action="store_true", help="Set bucket versioning status. (only for [setversioning] command)")
 
     optparser.set_usage(optparser.usage + " COMMAND [parameters]")
     optparser.set_description('S3cmd is a tool for managing objects in '+


### PR DESCRIPTION
- Command added
  - ~Enable versioning: `s3cmd setversioning s3://mybucket`~
  - ~Suspend versioning: `s3cmd setversioning s3://mybucket --versioning-suspended`~
  - Enable versioning: `s3cmd setversioning s3://mybucket enable`
  - Suspend versioning: `s3cmd setversioning s3://mybucket disable`
- Add versioning status to command `info`
  ```
  $ s3cmd info s3://mybucket
  ...
  Location:  us-east-1
  Payer:     BucketOwner
  Versioning:Suspended
  Expiration Rule: none
  Policy:    none
  ...
  ```

Resolve #937 