### PR TITLE
Handle MD5 from etag when upper-case are used.

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1870,7 +1870,7 @@ class S3(object):
         debug("MD5 sums: computed=%s, received=%s" % (md5_computed, response["headers"].get('etag', '').strip('"\'')))
         ## when using KMS encryption, MD5 etag value will not match
         md5_from_s3 = response["headers"].get("etag", "").strip('"\'')
-        if ('-' not in md5_from_s3) and (md5_from_s3 != md5_hash.hexdigest()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
+        if ('-' not in md5_from_s3) and (md5_from_s3.lower() != md5_computed.lower()) and response["headers"].get("x-amz-server-side-encryption") != 'aws:kms':
             warning("MD5 Sums don't match!")
             if retries:
                 warning("Retrying upload of %s" % (filename))


### PR DESCRIPTION
Some S3-compatible providers, like AlibabaCloud, return etag in upper-case (e.g. A256A58D6429BF79ABBC0DB3CEF2FC71)