### PR TITLE
bug: require object in abortmp

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -2357,10 +2357,12 @@ def cmd_multipart(args):
     return EX_OK
 
 def cmd_abort_multipart(args):
-    '''{"cmd":"abortmp",   "label":"abort a multipart upload", "param":"s3://BUCKET Id", "func":cmd_abort_multipart, "argc":2},'''
+    '''{"cmd":"abortmp",   "label":"abort a multipart upload", "param":"s3://BUCKET/OBJECT Id", "func":cmd_abort_multipart, "argc":2},'''
     cfg = Config()
     s3 = S3(cfg)
     uri = S3Uri(args[0])
+    if not uri.object():
+        raise ParameterError("S3Uri must include an object. Got: %s" % uri)
     id = args[1]
     response = s3.abort_multipart(uri, id)
     debug(u"response - %s" % response['status'])

--- a/s3cmd
+++ b/s3cmd
@@ -2362,7 +2362,7 @@ def cmd_abort_multipart(args):
     s3 = S3(cfg)
     uri = S3Uri(args[0])
     if not uri.object():
-        raise ParameterError("S3Uri must include an object. Got: %s" % uri)
+        raise ParameterError(u"Expecting S3 URI with a filename: %s" % uri.uri())
     id = args[1]
     response = s3.abort_multipart(uri, id)
     debug(u"response - %s" % response['status'])


### PR DESCRIPTION
Currently, if you only specify a bucket:
```
s3cmd abortmp s3://mybucket multipartid
```
Then the request will look like:
```
DELETE /mybucket/?uploadId=multipartid
```

In the case of `AWS` this isn't a huge deal:
```
ERROR: S3 error: 400 (InvalidRequest): A key must be specified
```

However, `ceph` interprets this as a delete **bucket** request not an **abortmp** request. If there are any regular objects in the bucket you get:
```
ERROR: S3 error: 409 (BucketNotEmpty)
```
But if all you have are incomplete multiparts then `ceph` **actually deletes the bucket**.

I intend to open a bug with ceph as well, but since `s3cmd` isn't following the S3 API spec I still think this PR is useful:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_AbortMultipartUpload.html

Let me know if there's a better approach / I should write a test for this.