### PR TITLE
Use generate_content_md5() in set_versioning command

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1088,7 +1088,7 @@ class S3(object):
         body += '<Status>%s</Status>' % status
         body += '</VersioningConfiguration>'
         debug(u"set_versioning(%s)" % body)
-        headers['content-md5'] = compute_content_md5(body)
+        headers['content-md5'] = generate_content_md5(body)
         request = self.create_request("BUCKET_CREATE", uri = uri,
                                       headers = headers, body = body,
                                       uri_params = {'versioning': None})


### PR DESCRIPTION
Fix to pr #1284, 
I didn't notice that there's a change from `compute_content_md5` to `generate_content_md5`.