### PR TITLE
Avoid unrecognized escape sequences

### DIFF
--- a/S3/BaseUtils.py
+++ b/S3/BaseUtils.py
@@ -74,8 +74,8 @@ __all__.append("md5")
 
 
 
-RE_S3_DATESTRING = re.compile('\.[0-9]*(?:[Z\\-\\+]*?)')
-RE_XML_NAMESPACE = re.compile(b'^(<?[^>]+?>\s*|\s*)(<\w+) xmlns=[\'"](https?://[^\'"]+)[\'"]', re.MULTILINE)
+RE_S3_DATESTRING = re.compile(r'\.[0-9]*(?:[Z\-+]*?)')
+RE_XML_NAMESPACE = re.compile(b'^(<?[^>]+?>\\s*|\\s*)(<\\w+) xmlns=[\'"](https?://[^\'"]+)[\'"]', re.MULTILINE)
 
 
 # Date and time helpers

--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -518,7 +518,7 @@ def fetch_remote_list(args, require_attribs = False, recursive = None, uri_param
             uri_str = uri.uri()
             ## Wildcards used in remote URI?
             ## If yes we'll need a bucket listing...
-            wildcard_split_result = re.split("\*|\?", uri_str, maxsplit=1)
+            wildcard_split_result = re.split(r"\*|\?", uri_str, maxsplit=1)
 
             if len(wildcard_split_result) == 2:
                 ## If wildcards found

--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -115,7 +115,7 @@ class S3UriS3(S3Uri):
 
         # Worst case scenario, we would like to be able to match something like
         # my.website.com.s3-fips.dualstack.us-west-1.amazonaws.com.cn
-        m = re.match("(.*\.)?s3(?:\-[^\.]*)?(?:\.dualstack)?(?:\.[^\.]*)?\.amazonaws\.com(?:\.cn)?$",
+        m = re.match(r"(.*\.)?s3(?:-[^.]*)?(?:\.dualstack)?(?:\.[^.]*)?\.amazonaws\.com(?:\.cn)?$",
                      hostname, re.IGNORECASE | re.UNICODE)
         if not m:
             raise ValueError("Unable to parse URL: %s" % http_url)
@@ -163,7 +163,7 @@ class S3UriS3FS(S3Uri):
 
 class S3UriFile(S3Uri):
     type = "file"
-    _re = re.compile("^(\w+://)?(.*)", re.UNICODE)
+    _re = re.compile(r"^(\w+://)?(.*)", re.UNICODE)
     def __init__(self, string):
         match = self._re.match(string)
         groups = match.groups()

--- a/S3/Utils.py
+++ b/S3/Utils.py
@@ -223,11 +223,11 @@ def time_to_epoch(t):
 
 def check_bucket_name(bucket, dns_strict=True):
     if dns_strict:
-        invalid = re.search("([^a-z0-9\.-])", bucket, re.UNICODE)
+        invalid = re.search("([^a-z0-9.-])", bucket, re.UNICODE)
         if invalid:
             raise S3.Exceptions.ParameterError("Bucket name '%s' contains disallowed character '%s'. The only supported ones are: lowercase us-ascii letters (a-z), digits (0-9), dot (.) and hyphen (-)." % (bucket, invalid.groups()[0]))
     else:
-        invalid = re.search("([^A-Za-z0-9\._-])", bucket, re.UNICODE)
+        invalid = re.search("([^A-Za-z0-9._-])", bucket, re.UNICODE)
         if invalid:
             raise S3.Exceptions.ParameterError("Bucket name '%s' contains disallowed character '%s'. The only supported ones are: us-ascii letters (a-z, A-Z), digits (0-9), dot (.), hyphen (-) and underscore (_)." % (bucket, invalid.groups()[0]))
 
@@ -238,9 +238,9 @@ def check_bucket_name(bucket, dns_strict=True):
     if dns_strict:
         if len(bucket) > 63:
             raise S3.Exceptions.ParameterError("Bucket name '%s' is too long (max 63 characters)" % bucket)
-        if re.search("-\.", bucket, re.UNICODE):
+        if re.search(r"-\.", bucket, re.UNICODE):
             raise S3.Exceptions.ParameterError("Bucket name '%s' must not contain sequence '-.' for DNS compatibility" % bucket)
-        if re.search("\.\.", bucket, re.UNICODE):
+        if re.search(r"\.\.", bucket, re.UNICODE):
             raise S3.Exceptions.ParameterError("Bucket name '%s' must not contain sequence '..' for DNS compatibility" % bucket)
         if not re.search("^[0-9a-z]", bucket, re.UNICODE):
             raise S3.Exceptions.ParameterError("Bucket name '%s' must start with a letter or a digit" % bucket)

--- a/run-tests.py
+++ b/run-tests.py
@@ -414,7 +414,7 @@ test_s3cmd("Sync to S3", ['sync', 'testsuite/', pbucket(1) + '/xyz/', '--exclude
            must_find = ["ERROR: Upload of 'testsuite/permission-tests/permission-denied.txt' is not possible (Reason: Permission denied)",
                         "WARNING: 32 non-printable characters replaced in: crappy-file-name/non-printables",
            ],
-           must_not_find_re = ["demo/", "^(?!WARNING: Skipping).*\.png$", "permission-denied-dir"],
+           must_not_find_re = ["demo/", r"^(?!WARNING: Skipping).*\.png$", "permission-denied-dir"],
            retcode = EX_PARTIAL)
 
 ## ====== Create new file and sync with caching enabled
@@ -702,7 +702,7 @@ test_s3cmd("Recursive copy, set ACL", ['cp', '-r', '--acl-public', '%s/xyz/' % p
 ## ====== Verify ACL and MIME type
 test_s3cmd("Verify ACL and MIME type", ['info', '%s/copy/etc2/Logo.PNG' % pbucket(2) ],
     must_find_re = [ "MIME type:.*image/png",
-                     "ACL:.*\*anon\*: READ",
+                     r"ACL:.*\*anon\*: READ",
                      "URL:.*https?://%s.%s/copy/etc2/Logo.PNG" % (bucket(2), cfg.host_base) ],
            skip_if_profile = ['minio'])
 
@@ -716,7 +716,7 @@ test_s3cmd("Modify MIME type", ['modify', '--mime-type=binary/octet-stream', '%s
 
 test_s3cmd("Verify ACL and MIME type", ['info', '%s/copy/etc2/Logo.PNG' % pbucket(2) ],
     must_find_re = [ "MIME type:.*binary/octet-stream",
-                     "ACL:.*\*anon\*: READ",
+                     r"ACL:.*\*anon\*: READ",
                      "URL:.*https?://%s.%s/copy/etc2/Logo.PNG" % (bucket(2), cfg.host_base) ],
            skip_if_profile = ['minio'])
 
@@ -731,7 +731,7 @@ test_s3cmd("Modify MIME type back", ['modify', '--mime-type=image/png', '%s/copy
 
 test_s3cmd("Verify ACL and MIME type", ['info', '%s/copy/etc2/Logo.PNG' % pbucket(2) ],
     must_find_re = [ "MIME type:.*image/png",
-                     "ACL:.*\*anon\*: READ",
+                     r"ACL:.*\*anon\*: READ",
                      "URL:.*https?://%s.%s/copy/etc2/Logo.PNG" % (bucket(2), cfg.host_base) ],
            skip_if_profile = ['minio'])
 


### PR DESCRIPTION
https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
indicates that unrecognized escape sequences produce a
`DeprecationWarning` and will eventually be a `SyntaxError`, so avoid
them.