### PR TITLE
fix #1332 SignatureDoesNotMatch error when modifying an object on Cloudflare R2

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -855,6 +855,8 @@ class S3(object):
             'server',
             'x-amz-id-2',
             'x-amz-request-id',
+            # Cloudflare's R2 header we don't want to send
+            'cf-ray',
             # Other headers that are not copying by a direct copy
             'x-amz-storage-class',
             ## We should probably also add server-side encryption headers


### PR DESCRIPTION
`s3cmd modify s3://myr2/photo.jpg`

> ERROR: Copy failed for: 's3://myr2/photo.jpg' (403 (SignatureDoesNotMatch): The request signature we calculated does not match the signature you provided. Check your secret access key and signing method. )

It happens because `s3cmd` is copying `cf-ray` header and using it for the signature.
A simple fix is to add cf-ray on the `_sanitize_headers` list.