### PR TITLE
Clarify the error message when a file cannot be opened for reading

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -700,7 +700,7 @@ class S3(object):
                     size = stat[ST_SIZE]
                 src_stream.stream_name = filename
         except (IOError, OSError) as e:
-            raise InvalidFileError(u"%s" % e.strerror)
+            raise InvalidFileError(u"failed to open the file for reading (%s)" % e.strerror)
 
         headers = SortedDict(ignore_case=True)
         if extra_headers:

--- a/s3cmd
+++ b/s3cmd
@@ -470,7 +470,7 @@ def cmd_object_put(args):
             ret = EX_PARTIAL
             continue
         except InvalidFileError as exc:
-            error(u"Upload of '%s' is not possible (Reason: %s)" % (full_name_orig, exc))
+            error(u"Upload of '%s' is not possible. Reason: %s." % (full_name_orig, exc))
             ret = EX_PARTIAL
             if cfg.stop_on_error:
                 ret = EX_OSFILE


### PR DESCRIPTION
When `s3cmd` cannot open a local file because the user has no permission to read it, it produces the following error message:

```
$ touch	test-file
$ sudo chmod root:root test-file
$ sudo chmod	600 test-file
$ s3cmd put ./file s3://some-bucket
ERROR: Upload of 'test-file' is not possible (Reason: Permission denied)

```

That message can mean two different things (at least to the user who doesn't see S3-side errors frequently): either the current user has no permission to read the file or the current AWS credentials do not permit its upload to the target bucket. When that happened to me lately, I spent a few minutes trying to figure out what was wrong with my AWS credentials before I  realized that `s3cmd` is actually talking about the _local_ file. :)

This PR changes the message to make it clear what actually happens:

```
$ ./s3cmd put test-file s3://some-bucket
ERROR: Upload of 'test-file' is not possible. Reason: failed to open the file for reading (Permission denied).
```

The `failed to open the file for reading` message is only prepended when `io.open(filename_bytes, mode='rb')` causes `OSError` or `IOError`, all other messages (special file, etc.) remain unchanged.

I took the liberty to change the format of the "Upload of ... is not possible" message to avoid nested parens there. If it's against your error message guidelines, please let me know.