### PR TITLE
fix: don't set delimiter if unordered list is enabled

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -388,7 +388,7 @@ class S3(object):
             uri_params = {}
         if prefix:
             uri_params['prefix'] = prefix
-        if not self.config.recursive and not recursive:
+        if not self.config.recursive and not recursive and not self.config.list_allow_unordered:
             uri_params['delimiter'] = "/"
         if max_keys != -1:
             uri_params['max-keys'] = str(max_keys)


### PR DESCRIPTION
As pointed out [here](https://github.com/s3tools/s3cmd/pull/1270#issuecomment-1803876803).

Also I'm thinking that delimiter should be configurable. but I'll open another PR for it.