### PR TITLE
fix utf-8 issues for python3.12

### DIFF
--- a/S3/BaseUtils.py
+++ b/S3/BaseUtils.py
@@ -78,8 +78,8 @@ __all__.append("md5")
 
 
 
-RE_S3_DATESTRING = re.compile('\\.[0-9]*(?:[Z\\-\\+]*?)')
-RE_XML_NAMESPACE = re.compile(b'^(<?[^>]+?>\\s*|\\s*)(<\\w+) xmlns=[\'"](https?://[^\'"]+)[\'"]', re.MULTILINE)
+RE_S3_DATESTRING = re.compile(r'\.[0-9]*(?:[Z\-\+]*?)')
+RE_XML_NAMESPACE = re.compile(r'^(<?[^>]+?>\s*|\s*)(<\w+) xmlns=[\'"](https?://[^\'"]+)[\'"]', re.MULTILINE)
 
 
 # Date and time helpers
@@ -274,10 +274,11 @@ def stripNameSpace(xml):
     removeNameSpace(xml) -- remove top-level AWS namespace
     Operate on raw byte(utf-8) xml string. (Not unicode)
     """
-    xmlns_match = RE_XML_NAMESPACE.match(xml)
+    xml_str = xml.decode('utf-8')
+    xmlns_match = RE_XML_NAMESPACE.match(xml_str)
     if xmlns_match:
         xmlns = xmlns_match.group(3)
-        xml = RE_XML_NAMESPACE.sub(b"\\1\\2", xml, 1)
+        xml = RE_XML_NAMESPACE.sub("\\1\\2", xml_str, 1)
     else:
         xmlns = None
     return xml, xmlns


### PR DESCRIPTION
s3cmd fails on python3.12 as follows 

```

Invoked as: /usr/bin/s3cmd ls -d
Problem: <class 'TypeError: sequence item 1: expected str instance, bytes found
S3cmd:   2.3.0
python:   3.12.0 (main, Oct 12 2023, 17:58:08) [GCC 13.2.0]
environment LANG=en_US.UTF-8

Traceback (most recent call last):
  File "/usr/bin/s3cmd", line 3286, in <module>
    rc = main()
         ^^^^^^
  File "/usr/bin/s3cmd", line 3183, in main
    rc = cmd_func(args)
         ^^^^^^^^^^^^^^
  File "/usr/bin/s3cmd", line 171, in cmd_ls
    subcmd_all_buckets_list(s3)
  File "/usr/bin/s3cmd", line 176, in subcmd_all_buckets_list
    response = s3.list_all_buckets()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/S3/S3.py", line 327, in list_all_buckets
    response["list"] = getListFromXml(response["data"], "Bucket")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/S3/BaseUtils.py", line 277, in getListFromXml
    tree = getTreeFromXml(xml)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/S3/BaseUtils.py", line 263, in getTreeFromXml
    xml, xmlns = stripNameSpace(encode_to_s3(xml))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/S3/BaseUtils.py", line 255, in stripNameSpace
    xml = RE_XML_NAMESPACE.sub("\\1\\2", xml, 1)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 1: expected str instance, bytes found
```