### PR TITLE
Fix `dict_keys` indexing

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -1405,7 +1405,7 @@ def cmd_sync_remote2local(args):
             if not os.path.isdir(deunicodise(destination_base)):
                 raise ParameterError("Destination is not an existing directory")
         elif len(remote_list) == 1 and \
-             source_args[0] == remote_list[remote_list.keys()[0]].get(u'object_uri_str', ''):
+            source_args[0] == remote_list[list(remote_list.keys())[0]].get(u'object_uri_str', ''):
             if os.path.isdir(deunicodise(destination_base)):
                 raise ParameterError("Destination already exists and is a directory")
             remote_list[remote_list.keys()[0]]['local_filename'] = destination_base


### PR DESCRIPTION
s3cmd fails on python3.6 as follows
```sh
Traceback (most recent call last):
  File "/usr/bin/s3cmd", line 3627, in <module>
    rc = main()
  File "/usr/bin/s3cmd", line 3524, in main
    rc = cmd_func(args)
  File "/usr/bin/s3cmd", line 2163, in cmd_sync
    return cmd_sync_remote2local(args)
  File "/usr/bin/s3cmd", line 1719, in cmd_sync_remote2local
    _set_local_filename(copy_pairs, destination_base, source_args, dir_cache)
  File "/usr/bin/s3cmd", line 1408, in _set_local_filename
    source_args[0] == remote_list[remote_list.keys()[0]].get(u'object_uri_str', ''):
TypeError: 'dict_keys' object does not support indexing
```

Fixes:
- #1363 