### PR TITLE
Fixes #1361 and #1027 - update to python 3.2+ API (existing code calls removed API)

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -73,7 +73,7 @@ except NameError:
     # In python 3, unicode -> str, and str -> bytes
     unicode = str
 
-PY32 = (sys.version_info >= (3, 2))
+PY3 = (sys.version_info >= (3, 0))
 
 
 def is_bool_true(value):
@@ -459,7 +459,7 @@ class Config(object):
             try:
                 try:
                     buf = io.StringIO(config_string)
-                    if PY32:
+                    if PY3:
                       config.read_file(buf)
                     else:
                       config.readfp(buf)
@@ -471,7 +471,7 @@ class Config(object):
                     # to be able to read the file with PyConfigParser()
                     config_string = u'[default]\n' + config_string
                     buf = io.StringIO(config_string)
-                    if PY32:
+                    if PY3:
                       config.read_file(buf)
                     else:
                       config.readfp(buf)

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -268,7 +268,7 @@ class Config(object):
             try:
                 self.read_config_file(configfile)
             except IOError:
-                if 'AWS_CREDENTIAL_FILE' in os.environ or 'AWS_PROFILE' in os.environ:
+                if 'AWS_SHARED_CREDENTIALS_FILE' in os.environ or 'AWS_CREDENTIAL_FILE' in os.environ or 'AWS_PROFILE' in os.environ:
                     self.aws_credential_file()
 
             # override these if passed on the command-line
@@ -439,7 +439,8 @@ class Config(object):
     def aws_credential_file(self):
         try:
             aws_credential_file = os.path.expanduser('~/.aws/credentials')
-            credential_file_from_env = os.environ.get('AWS_CREDENTIAL_FILE')
+            credential_file_from_env = os.environ.get('AWS_SHARED_CREDENTIALS_FILE') \
+                or os.environ.get('AWS_CREDENTIAL_FILE')
             if credential_file_from_env and \
                os.path.isfile(credential_file_from_env):
                 aws_credential_file = base_unicodise(credential_file_from_env)
@@ -454,9 +455,7 @@ class Config(object):
                 config_string = fp.read()
             try:
                 try:
-                    # readfp is replaced by read_file in python3,
-                    # but so far readfp it is still available.
-                    config.readfp(io.StringIO(config_string))
+                    config.read_file(io.StringIO(config_string))
                 except MissingSectionHeaderError:
                     # if header is missing, this could be deprecated
                     # credentials file format as described here:
@@ -464,7 +463,7 @@ class Config(object):
                     # then do the hacky-hack and add default header
                     # to be able to read the file with PyConfigParser()
                     config_string = u'[default]\n' + config_string
-                    config.readfp(io.StringIO(config_string))
+                    config.read_file(io.StringIO(config_string))
             except ParsingError as exc:
                 raise ValueError(
                     "Error reading aws_credential_file "

--- a/S3/Config.py
+++ b/S3/Config.py
@@ -73,6 +73,8 @@ except NameError:
     # In python 3, unicode -> str, and str -> bytes
     unicode = str
 
+PY32 = (sys.version_info >= (3, 2))
+
 
 def is_bool_true(value):
     """Check to see if a string is true, yes, on, or 1
@@ -456,7 +458,11 @@ class Config(object):
                 config_string = fp.read()
             try:
                 try:
-                    config.read_file(io.StringIO(config_string))
+                    buf = io.StringIO(config_string)
+                    if PY32:
+                      config.read_file(buf)
+                    else:
+                      config.readfp(buf)
                 except MissingSectionHeaderError:
                     # if header is missing, this could be deprecated
                     # credentials file format as described here:
@@ -464,7 +470,11 @@ class Config(object):
                     # then do the hacky-hack and add default header
                     # to be able to read the file with PyConfigParser()
                     config_string = u'[default]\n' + config_string
-                    config.read_file(io.StringIO(config_string))
+                    buf = io.StringIO(config_string)
+                    if PY32:
+                      config.read_file(buf)
+                    else:
+                      config.readfp(buf)
             except ParsingError as exc:
                 raise ValueError(
                     "Error reading aws_credential_file "


### PR DESCRIPTION
Fixes:

- https://github.com/s3tools/s3cmd/issues/1361
- https://github.com/s3tools/s3cmd/issues/1027

Should be OK to replace the removed API call, since the replacement was added in python 3.2.

https://docs.python.org/3/library/configparser.html