### PR TITLE
cleanup: fixes regex escape warnings in S3Uri.py, FileLists.py

### DIFF
--- a/S3/FileLists.py
+++ b/S3/FileLists.py
@@ -522,7 +522,7 @@ def fetch_remote_list(args, require_attribs = False, recursive = None, uri_param
             uri_str = uri.uri()
             ## Wildcards used in remote URI?
             ## If yes we'll need a bucket listing...
-            wildcard_split_result = re.split("\*|\?", uri_str, maxsplit=1)
+            wildcard_split_result = re.split(r"\*|\?", uri_str, maxsplit=1)
 
             if len(wildcard_split_result) == 2:
                 ## If wildcards found

--- a/S3/S3Uri.py
+++ b/S3/S3Uri.py
@@ -119,7 +119,7 @@ class S3UriS3(S3Uri):
 
         # Worst case scenario, we would like to be able to match something like
         # my.website.com.s3-fips.dualstack.us-west-1.amazonaws.com.cn
-        m = re.match("(.*\.)?s3(?:\-[^\.]*)?(?:\.dualstack)?(?:\.[^\.]*)?\.amazonaws\.com(?:\.cn)?$",
+        m = re.match(r"(.*\.)?s3(?:\-[^\.]*)?(?:\.dualstack)?(?:\.[^\.]*)?\.amazonaws\.com(?:\.cn)?$",
                      hostname, re.IGNORECASE | re.UNICODE)
         if not m:
             raise ValueError("Unable to parse URL: %s" % http_url)
@@ -167,7 +167,7 @@ class S3UriS3FS(S3Uri):
 
 class S3UriFile(S3Uri):
     type = "file"
-    _re = re.compile("^(\w+://)?(.*)", re.UNICODE)
+    _re = re.compile(r"^(\w+://)?(.*)", re.UNICODE)
     def __init__(self, string):
         match = self._re.match(string)
         groups = match.groups()


### PR DESCRIPTION
Hi,

Similar to the regex escaping issues reported in #1351, it looks like there are still a few invalid escape sequences in `S3Uri.py` and `FileLists.py` in `s3cmd` version 2.4.0.

I saw these warnings while uploading a file:
```
/usr/local/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.12/site-packages/S3/S3Uri.py:122: SyntaxWarning: invalid escape sequence '\.'
  m = re.match("(.*\.)?s3(?:\-[^\.]*)?(?:\.dualstack)?(?:\.[^\.]*)?\.amazonaws\.com(?:\.cn)?$",
/usr/local/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.12/site-packages/S3/S3Uri.py:173: SyntaxWarning: invalid escape sequence '\w'
  _re = re.compile("^(\w+://)?(.*)", re.UNICODE)
/usr/local/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.12/site-packages/S3/FileLists.py:525: SyntaxWarning: invalid escape sequence '\*'
  wildcard_split_result = re.split("\*|\?", uri_str, maxsplit=1)
```
The first is from this line: https://github.com/s3tools/s3cmd/blob/dbdee8fa850b8c41249c22dc44b1bd6d3116a06d/S3/S3Uri.py#L122-L123

The `\` characters are interpreted as escaping characters in the Python string itself.

The second warning is about the same issue for a different line, where only one `\` needs to be escaped or at least interpreted differently, the one in `\w`: https://github.com/s3tools/s3cmd/blob/dbdee8fa850b8c41249c22dc44b1bd6d3116a06d/S3/S3Uri.py#L170

And the third one from here: https://github.com/s3tools/s3cmd/blob/dbdee8fa850b8c41249c22dc44b1bd6d3116a06d/S3/FileLists.py#L525

There are many different ways to fix this problem, but I saw that commit 7ebafbedd77ee238c18722463de0774579bcda03 was linked from #1351 so I used the same technique here, I hope this works for you.