### PR TITLE
Correct typo in error msg in S3._http_400_handler() #1379

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1621,7 +1621,7 @@ class S3(object):
                     info('Forwarding request to %s', region)
                     return fn(*args, **kwargs)
                 else:
-                    warning(u'Could not determine bucket the location. Please consider using the --region parameter.')
+                    warning(u'Could not determine the bucket location. Please consider using the --region parameter.')
 
             elif failureCode == 'InvalidRequest':
                 message = getTextFromXml(response['data'], 'Message')


### PR DESCRIPTION
Correct typo in error message in S3._http_400_handler method of the `S3/S3.py` file.
fixes #1379 