### PR TITLE
Fix file extension detection for files with multiple dot separators

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -738,7 +738,7 @@ class S3(object):
         parts = filename.rsplit('.', 1)
         if len(parts) < 2:
             return False
-        ext = parts[-1]
+        ext = parts[1]
         if ext in exts:
             return True
         else:

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -728,15 +728,14 @@ class S3(object):
         return content_type
 
     def add_encoding(self, filename, content_type):
+        if not filename:
+            return False
         if 'charset=' in content_type:
            return False
         exts = self.config.add_encoding_exts.split(',')
         if exts[0]=='':
             return False
-        parts = filename.rsplit('.',2)
-        if len(parts) < 2:
-            return False
-        ext = parts[1]
+        ext = filename.rsplit('.', 1)[-1]
         if ext in exts:
             return True
         else:

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -735,7 +735,10 @@ class S3(object):
         exts = self.config.add_encoding_exts.split(',')
         if exts[0]=='':
             return False
-        ext = filename.rsplit('.', 1)[-1]
+        parts = filename.rsplit('.', 1)
+        if len(parts) < 2:
+            return False
+        ext = parts[-1]
         if ext in exts:
             return True
         else:


### PR DESCRIPTION
Hi!

I have issues with the flag `--add-encoding-exts=js,html,css` when uploads js static on production buckets. My files have names like `widget-no-csr.oWiXNN3Poy.js` or `widget-no-csr.oWiXNN3Poy.js.gz`, where is more than one dot symbol separator. Because https://github.com/s3tools/s3cmd/blob/10aea0918082ea87723a7e6754133283883bcfa7/S3/S3.py#L736 there is file extension `oWiXNN3Poy` for first file and `js` for second. That looks like a bug. I fixed that, but I think it could be kind of dangerous because it breaks backward compability.