### PR TITLE
fix: redirection based on location header for methods other than HEAD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ s3cmd.egg-info
 s3cmd.spec
 .idea
 .s3cfg
+.python-version

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1581,7 +1581,7 @@ class S3(object):
                 S3Request.region_map[redir_bucket] = redir_region
                 info(u'Redirected to region: %s', redir_region)
             return fn(*args, **kwargs)
-        elif request.method_string == 'HEAD':
+        elif response['headers'].get('location'):
             # Head is a special case, redirection info usually are in the body
             # but there is no body for an HEAD request.
             location_url = response['headers'].get('location')


### PR DESCRIPTION
The location header can be provided with methods other than HEAD.