### PR TITLE
fix: allow blank secret key

### DIFF
--- a/S3/Config.py
+++ b/S3/Config.py
@@ -272,7 +272,8 @@ class Config(object):
                     self.aws_credential_file()
 
             # override these if passed on the command-line
-            if access_key and secret_key:
+            # Allow blank secret_key
+            if access_key and secret_key is not None:
                 self.access_key = access_key
                 self.secret_key = secret_key
             if access_token:


### PR DESCRIPTION
Fixes #1385

This PR allows blank but not null secret_keys provided by command-line switch to also override config file.