### PR TITLE
Add listacl listpolicy

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -20,6 +20,7 @@ import mimetypes
 import io
 import pprint
 from xml.sax import saxutils
+import xml.dom.minidom
 from socket import timeout as SocketTimeoutException
 from logging import debug, info, warning, error
 from stat import ST_SIZE, ST_MODE, S_ISDIR, S_ISREG
@@ -1221,14 +1222,6 @@ class S3(object):
         request = self.create_request("BUCKET_CREATE", uri = uri,
                                       headers=headers, body = policy,
                                       uri_params = {'policy': None})
-        response = self.send_request(request)
-        return response
-
-    def list_policy(self, uri):
-        headers = SortedDict(ignore_case = True)
-        headers['content-type'] = 'application/json'
-        request = self.create_request("BUCKET_LIST", uri = uri,
-                                        headers=headers, uri_params = {'policy': None})
         response = self.send_request(request)
         return response
 

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -1224,6 +1224,14 @@ class S3(object):
         response = self.send_request(request)
         return response
 
+    def list_policy(self, uri):
+        headers = SortedDict(ignore_case = True)
+        headers['content-type'] = 'application/json'
+        request = self.create_request("BUCKET_LIST", uri = uri,
+                                        headers=headers, uri_params = {'policy': None})
+        response = self.send_request(request)
+        return response
+
     def delete_policy(self, uri):
         request = self.create_request("BUCKET_DELETE", uri = uri,
                                       uri_params = {'policy': None})

--- a/S3/S3.py
+++ b/S3/S3.py
@@ -20,7 +20,6 @@ import mimetypes
 import io
 import pprint
 from xml.sax import saxutils
-import xml.dom.minidom
 from socket import timeout as SocketTimeoutException
 from logging import debug, info, warning, error
 from stat import ST_SIZE, ST_MODE, S_ISDIR, S_ISREG

--- a/s3cmd
+++ b/s3cmd
@@ -2174,11 +2174,11 @@ def cmd_sync(args):
 def cmd_getacl(args):
     cfg = Config()
     s3 = S3(cfg)
-    if len(args) != 1:
-        raise ParameterError("Too few parameters! Expected: <bucket>")
-    if not S3Uri(args[0]).has_bucket():
-        raise ParameterError("Invalid bucket name: '%s'" % args[0])
     uri = S3Uri(args[0])
+    
+    if uri.type != "s3" or not uri.has_bucket():
+        raise ParameterError("Expecting S3 URI instead of '%s'" % args[0])
+    
     try:
         acl = s3.get_acl(uri)
         acl_grant_list = acl.getGrantList()

--- a/s3cmd
+++ b/s3cmd
@@ -2171,7 +2171,7 @@ def cmd_sync(args):
         return cmd_sync_remote2remote(args)
     raise ParameterError("Invalid source/destination: '%s'" % "' '".join(args))
 
-def cmd_listacl(args):
+def cmd_getacl(args):
     cfg = Config()
     s3 = S3(cfg)
     if len(args) != 1:
@@ -2179,7 +2179,25 @@ def cmd_listacl(args):
     if not S3Uri(args[0]).has_bucket():
         raise ParameterError("Invalid bucket name: '%s'" % args[0])
     uri = S3Uri(args[0])
-    acl = list_acl(s3, uri)
+    try:
+        acl = s3.get_acl(uri)
+        acl_grant_list = acl.getGrantList()
+        owner = acl.getOwner()
+        output(u"Bucket:     %s" % uri.bucket())
+        output(u"Owner:      %s (ID: %s)" % (owner['nick'], owner['id']))
+        for grant in acl_grant_list:
+            output(u"   ACL:       %s: %s" % (grant['grantee'], grant['permission']))
+        if acl.isAnonRead():
+            output(u"   URL:       %s" % uri.public_url())
+        output(u"\nRaw ACL Output: \n %s" % acl)
+    except S3Error as exc:
+        # Ignore the exception and don't fail the info
+        # if the server doesn't support setting ACLs
+        if exc.status not in [404, 501]:
+            raise exc
+        else:
+            output(u"   ACL:       none")
+
     return acl
         
 def cmd_setacl(args):
@@ -2369,12 +2387,9 @@ def cmd_listpolicy(args):
     if uri.has_object():
         raise ParameterError("No Object Names allowed: '%s'" % args[0])
 
-    response = s3.list_policy(uri)
+    response = s3.get_policy(uri)
 
-    debug(u"response - %s" % response['status'])
-    if response['status'] == 200:
-        output(u"%s: Policy listed" % uri)
-    return EX_OK
+    return response
 
 def cmd_delpolicy(args):
     cfg = Config()
@@ -3010,7 +3025,7 @@ def get_commands_list():
     {"cmd":"cp", "label":"Copy object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_cp, "argc":2},
     {"cmd":"modify", "label":"Modify object metadata", "param":"s3://BUCKET1/OBJECT", "func":cmd_modify, "argc":1},
     {"cmd":"mv", "label":"Move object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_mv, "argc":2},
-    {"cmd":"listacl", "label":"List Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_listacl, "argc":0},
+    {"cmd":"getacl", "label":"List Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_getacl, "argc":0},
     {"cmd":"setacl", "label":"Modify Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_setacl, "argc":1},
     {"cmd":"setversioning", "label":"Modify Bucket Versioning", "param":"s3://BUCKET enable|disable", "func":cmd_setversioning, "argc":2},
     {"cmd":"setownership", "label":"Modify Bucket Object Ownership", "param":"s3://BUCKET BucketOwnerPreferred|BucketOwnerEnforced|ObjectWriter", "func":cmd_setownership, "argc":2},
@@ -3072,12 +3087,6 @@ def format_commands(progname, commands_list):
     for cmd in commands_list:
         help += "  %s\n      %s %s %s\n" % (cmd["label"], progname, cmd["cmd"], cmd["param"])
     return help
-
-def list_acl(s3, uri):
-    cfg = Config()
-    acl = s3.get_acl(uri)
-    output(u"%s: ACL Listed" % uri)
-    return acl
 
 def update_acl(s3, uri, seq_label=""):
     cfg = Config()

--- a/s3cmd
+++ b/s3cmd
@@ -2178,8 +2178,6 @@ def cmd_listacl(args):
         raise ParameterError("Too few parameters! Expected: <bucket>")
     if not S3Uri(args[0]).has_bucket():
         raise ParameterError("Invalid bucket name: '%s'" % args[0])
-    if not S3Uri(args[0]).has_object():
-        raise ParameterError("Invalid object name: '%s'" % args[0])
     uri = S3Uri(args[0])
     acl = list_acl(s3, uri)
     return acl

--- a/s3cmd
+++ b/s3cmd
@@ -2171,6 +2171,19 @@ def cmd_sync(args):
         return cmd_sync_remote2remote(args)
     raise ParameterError("Invalid source/destination: '%s'" % "' '".join(args))
 
+def cmd_listacl(args):
+    cfg = Config()
+    s3 = S3(cfg)
+    if len(args) != 1:
+        raise ParameterError("Too few parameters! Expected: <bucket>")
+    if not S3Uri(args[0]).has_bucket():
+        raise ParameterError("Invalid bucket name: '%s'" % args[0])
+    if not S3Uri(args[0]).has_object():
+        raise ParameterError("Invalid object name: '%s'" % args[0])
+    uri = S3Uri(args[0])
+    acl = list_acl(s3, uri)
+    return acl
+        
 def cmd_setacl(args):
     cfg = Config()
     s3 = S3(cfg)
@@ -2344,6 +2357,18 @@ def cmd_setpolicy(args):
     debug(u"response - %s" % response['status'])
     if response['status'] == 204:
         output(u"%s: Policy updated" % uri)
+    return EX_OK
+
+def cmd_listpolicy(args):
+    cfg = Config()
+    s3 = S3(cfg)
+    uri = S3Uri(args[0])
+
+    response = s3.list_policy(uri)
+
+    debug(u"response - %s" % response['status'])
+    if response['status'] == 200:
+        output(u"%s: Policy listed" % uri)
     return EX_OK
 
 def cmd_delpolicy(args):
@@ -2980,6 +3005,7 @@ def get_commands_list():
     {"cmd":"cp", "label":"Copy object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_cp, "argc":2},
     {"cmd":"modify", "label":"Modify object metadata", "param":"s3://BUCKET1/OBJECT", "func":cmd_modify, "argc":1},
     {"cmd":"mv", "label":"Move object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_mv, "argc":2},
+    {"cmd":"listacl", "label":"List Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_listacl, "argc":0},
     {"cmd":"setacl", "label":"Modify Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_setacl, "argc":1},
     {"cmd":"setversioning", "label":"Modify Bucket Versioning", "param":"s3://BUCKET enable|disable", "func":cmd_setversioning, "argc":2},
     {"cmd":"setownership", "label":"Modify Bucket Object Ownership", "param":"s3://BUCKET BucketOwnerPreferred|BucketOwnerEnforced|ObjectWriter", "func":cmd_setownership, "argc":2},
@@ -2989,6 +3015,7 @@ def get_commands_list():
     {"cmd":"setobjectretention", "label":"Modify Object Retention", "param":"MODE RETAIN_UNTIL_DATE s3://BUCKET/OBJECT", "func":cmd_setobjectretention, "argc":3},
 
     {"cmd":"setpolicy", "label":"Modify Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_setpolicy, "argc":2},
+    {"cmd":"listpolicy", "label":"List Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_listpolicy, "argc":0},
     {"cmd":"delpolicy", "label":"Delete Bucket Policy", "param":"s3://BUCKET", "func":cmd_delpolicy, "argc":1},
     {"cmd":"setcors", "label":"Modify Bucket CORS", "param":"FILE s3://BUCKET", "func":cmd_setcors, "argc":2},
     {"cmd":"delcors", "label":"Delete Bucket CORS", "param":"s3://BUCKET", "func":cmd_delcors, "argc":1},
@@ -3041,6 +3068,11 @@ def format_commands(progname, commands_list):
         help += "  %s\n      %s %s %s\n" % (cmd["label"], progname, cmd["cmd"], cmd["param"])
     return help
 
+def list_acl(s3, uri):
+    cfg = Config()
+    acl = s3.get_acl(uri)
+    output(u"%s: ACL Listed" % uri)
+    return acl
 
 def update_acl(s3, uri, seq_label=""):
     cfg = Config()

--- a/s3cmd
+++ b/s3cmd
@@ -2179,23 +2179,22 @@ def cmd_getacl(args):
     if uri.type != "s3" or not uri.has_bucket():
         raise ParameterError("Expecting S3 URI instead of '%s'" % args[0])
     
-    try:
-        acl = s3.get_acl(uri)
-        acl_grant_list = acl.getGrantList()
-        owner = acl.getOwner()
-        output(u"%s (bucket):" % uri.uri())
-        if owner['nick'] is None or owner['nick'] == "":
-            output(u"   Owner:      %s" % (owner['id']))
-        else:
-            output(u"   Owner:      %s (Nick: %s)" % (owner['id'], owner['nick']))
-        for grant in acl_grant_list:
-            output(u"   ACL:       %s: %s" % (grant['grantee'], grant['permission']))
-        if acl.isAnonRead():
-            output(u"   URL:       %s" % uri.public_url())
-    except S3Error as exc:
-        # Ignore the exception and don't fail the info
-        # if the server doesn't support setting ACLs
-        output(u"   ACL:       none")
+    acl = s3.get_acl(uri)
+    acl_grant_list = acl.getGrantList()
+    owner = acl.getOwner()
+    if uri.has_object():
+        uri_type = "(object)"
+    else:
+        uri_type = "(bucket)"
+    output(u"%s %s:" % (uri, uri_type))
+    if not owner['nick']:
+        output(u"   Owner:     %s" % (owner['id']))
+    else:
+        output(u"   Owner:     %s (Nick: %s)" % (owner['id'], owner['nick']))
+    for grant in acl_grant_list:
+        output(u"   ACL:       %s: %s" % (grant['grantee'], grant['permission']))
+    if acl.isAnonRead():
+        output(u"   URL:       %s" % uri.public_url())
     return EX_OK
         
 def cmd_setacl(args):
@@ -2389,8 +2388,10 @@ def cmd_getpolicy(args):
         # if the server doesn't support setting ACLs
         if exc.status == 403:
             output(u"   Policy:    Not available: GetPolicy permission is needed to read the policy")
+            return EX_ACCESSDENIED
         elif exc.status == 405:
             output(u"   Policy:    Not available: Only the bucket owner can read the policy")
+            return EX_ACCESSDENIED
         elif exc.status not in [404, 501]:
             raise exc
         else:

--- a/s3cmd
+++ b/s3cmd
@@ -2364,6 +2364,13 @@ def cmd_listpolicy(args):
     s3 = S3(cfg)
     uri = S3Uri(args[0])
 
+    if len(args) != 1:
+        raise ParameterError("Too few parameters! Expected: <bucket>")
+    if not uri.has_bucket():
+        raise ParameterError("Invalid bucket name: '%s'" % args[0])
+    if uri.has_object():
+        raise ParameterError("No Object Names allowed: '%s'" % args[0])
+
     response = s3.list_policy(uri)
 
     debug(u"response - %s" % response['status'])

--- a/s3cmd
+++ b/s3cmd
@@ -2183,22 +2183,20 @@ def cmd_getacl(args):
         acl = s3.get_acl(uri)
         acl_grant_list = acl.getGrantList()
         owner = acl.getOwner()
-        output(u"Bucket:     %s" % uri.bucket())
-        output(u"Owner:      %s (ID: %s)" % (owner['nick'], owner['id']))
+        output(u"%s (bucket):" % uri.uri())
+        if owner['nick'] is None or owner['nick'] == "":
+            output(u"   Owner:      %s" % (owner['id']))
+        else:
+            output(u"   Owner:      %s (Nick: %s)" % (owner['id'], owner['nick']))
         for grant in acl_grant_list:
             output(u"   ACL:       %s: %s" % (grant['grantee'], grant['permission']))
         if acl.isAnonRead():
             output(u"   URL:       %s" % uri.public_url())
-        output(u"\nRaw ACL Output: \n %s" % acl)
     except S3Error as exc:
         # Ignore the exception and don't fail the info
         # if the server doesn't support setting ACLs
-        if exc.status not in [404, 501]:
-            raise exc
-        else:
-            output(u"   ACL:       none")
-
-    return acl
+        output(u"   ACL:       none")
+    return EX_OK
         
 def cmd_setacl(args):
     cfg = Config()
@@ -2375,21 +2373,29 @@ def cmd_setpolicy(args):
         output(u"%s: Policy updated" % uri)
     return EX_OK
 
-def cmd_listpolicy(args):
+def cmd_getpolicy(args):
     cfg = Config()
     s3 = S3(cfg)
     uri = S3Uri(args[0])
 
-    if len(args) != 1:
-        raise ParameterError("Too few parameters! Expected: <bucket>")
-    if not uri.has_bucket():
-        raise ParameterError("Invalid bucket name: '%s'" % args[0])
-    if uri.has_object():
-        raise ParameterError("No Object Names allowed: '%s'" % args[0])
+    if uri.type != "s3" or not uri.has_bucket():
+        raise ParameterError("Expecting S3 URI instead of '%s'" % args[0])
 
-    response = s3.get_policy(uri)
-
-    return response
+    try:
+        policy = s3.get_policy(uri)
+        output(u"   Policy:    %s" % policy)
+    except S3Error as exc:
+        # Ignore the exception and don't fail the info
+        # if the server doesn't support setting ACLs
+        if exc.status == 403:
+            output(u"   Policy:    Not available: GetPolicy permission is needed to read the policy")
+        elif exc.status == 405:
+            output(u"   Policy:    Not available: Only the bucket owner can read the policy")
+        elif exc.status not in [404, 501]:
+            raise exc
+        else:
+            output(u"   Policy:    none")
+    return EX_OK
 
 def cmd_delpolicy(args):
     cfg = Config()
@@ -3025,7 +3031,7 @@ def get_commands_list():
     {"cmd":"cp", "label":"Copy object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_cp, "argc":2},
     {"cmd":"modify", "label":"Modify object metadata", "param":"s3://BUCKET1/OBJECT", "func":cmd_modify, "argc":1},
     {"cmd":"mv", "label":"Move object", "param":"s3://BUCKET1/OBJECT1 s3://BUCKET2[/OBJECT2]", "func":cmd_mv, "argc":2},
-    {"cmd":"getacl", "label":"List Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_getacl, "argc":0},
+    {"cmd":"getacl", "label":"List Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_getacl, "argc":1},
     {"cmd":"setacl", "label":"Modify Access control list for Bucket or Files", "param":"s3://BUCKET[/OBJECT]", "func":cmd_setacl, "argc":1},
     {"cmd":"setversioning", "label":"Modify Bucket Versioning", "param":"s3://BUCKET enable|disable", "func":cmd_setversioning, "argc":2},
     {"cmd":"setownership", "label":"Modify Bucket Object Ownership", "param":"s3://BUCKET BucketOwnerPreferred|BucketOwnerEnforced|ObjectWriter", "func":cmd_setownership, "argc":2},
@@ -3035,7 +3041,7 @@ def get_commands_list():
     {"cmd":"setobjectretention", "label":"Modify Object Retention", "param":"MODE RETAIN_UNTIL_DATE s3://BUCKET/OBJECT", "func":cmd_setobjectretention, "argc":3},
 
     {"cmd":"setpolicy", "label":"Modify Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_setpolicy, "argc":2},
-    {"cmd":"listpolicy", "label":"List Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_listpolicy, "argc":0},
+    {"cmd":"getpolicy", "label":"Get Bucket Policy", "param":"FILE s3://BUCKET", "func":cmd_getpolicy, "argc":1},
     {"cmd":"delpolicy", "label":"Delete Bucket Policy", "param":"s3://BUCKET", "func":cmd_delpolicy, "argc":1},
     {"cmd":"setcors", "label":"Modify Bucket CORS", "param":"FILE s3://BUCKET", "func":cmd_setcors, "argc":2},
     {"cmd":"delcors", "label":"Delete Bucket CORS", "param":"s3://BUCKET", "func":cmd_delcors, "argc":1},


### PR DESCRIPTION
I added some very simple commands to list the Policy and ACL. It seems like it's almost a design decission that this wasn't there... but since I missed it, i thought maybe others find it useful, too. 

Example Usage:
python3 s3cmd -c ceph.cfg listacl s3://test3
python3 s3cmd -c ceph.cfg listacl s3://test3/test.txt
python3 s3cmd -c ceph.cfg listpolicy s3://test3

I was only able to test this on ceph unfortunately.