### PR TITLE
update: remove content-encoding header when calculate Sign

### DIFF
--- a/S3/S3.py
+++ b/S3/S3.py
@@ -921,6 +921,7 @@ class S3(object):
             # from http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
             'date',
             'content-length',
+            'content-encoding',
             'last-modified',
             'content-md5',
             'x-amz-version-id',


### PR DESCRIPTION
To support the compression algorithm on HTTP, it is need to set the response encoding format when uploading