### PR TITLE
fix: cmd_object_put check not exists bucket

### DIFF
--- a/s3cmd
+++ b/s3cmd
@@ -402,6 +402,13 @@ def cmd_object_put(args):
         raise ParameterError("Destination must be S3Uri. Got: %s" % destination_base_uri)
     destination_base = destination_base_uri.uri()
 
+    check_uri = S3UriS3(destination_base)
+    check_bucket = check_uri.bucket()
+
+    if not any(bucket['Name'] == check_bucket for bucket in s3.list_all_buckets()['list']):
+        error(u"Bucket '%s' does not exist" % check_bucket)
+        return EX_NOTFOUND
+
     if len(args) == 0:
         raise ParameterError("Nothing to upload. Expecting a local file or directory.")
 
@@ -3612,7 +3619,7 @@ if __name__ == '__main__':
         from S3.Config import Config
         from S3.SortedDict import SortedDict
         from S3.FileDict import FileDict
-        from S3.S3Uri import S3Uri
+        from S3.S3Uri import S3Uri, S3UriS3
         from S3 import Utils
         from S3.BaseUtils import (formatDateTime, getPrettyFromXml,
                                   encode_to_s3, decode_from_s3, s3path)


### PR DESCRIPTION
In the cmd_object_put function, after checking the type of the URL, verify whether the passed bucket exists.

The reason for doing this is that in a self-built S3 Server, I attempted to upload to a non-existent bucket using s3cmd, similar to 's3cmd put hello s3://b02', where b02does not exist, but the operation still succeeded(and the file could even be downloaded). This issue arises due to a design flaw in our S3 Server.

``` bash
$ ./s3cmd put setup.cfg s3://b02
upload: 'setup.cfg' -> 's3://b02/setup.cfg'  [1 of 1]
56 of 56   100% in    0s    11.63 KB/s  done
```

``` bash
$ mc put setup.cfg myio/b02
mc: <ERROR> unable to upload. Bucket `b02` does not exist.
```

However, similar clients like the MinIO client would directly return an error stating that the bucket b02 does not exist.Therefore, I believe it is necessary for s3cmd to include this check.

``` bash
$ ./s3cmd put setup.cfg s3://b02
ERROR: Bucket 'b02' does not exist
```